### PR TITLE
[Refactor] 공연 신청 내역 상세 조회 시, 대기 상태 외의 공연도 보이도록 로직 수정 

### DIFF
--- a/src/main/java/com/prography/lighton/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/lighton/common/exception/GlobalExceptionHandler.java
@@ -8,6 +8,7 @@ import com.prography.lighton.common.exception.base.NotFoundException;
 import com.prography.lighton.common.exception.base.UnsupportedTypeException;
 import com.prography.lighton.common.utils.ApiUtils;
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
+import com.prography.lighton.performance.admin.application.exception.PerformanceAlreadyProcessedException;
 import com.prography.lighton.performance.common.domain.exception.MasterArtistCannotBeRemovedException;
 import com.prography.lighton.performance.common.domain.exception.PerformanceNotApprovedException;
 import com.prography.lighton.performance.common.domain.exception.PerformanceUpdateNotAllowedException;
@@ -107,5 +108,9 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(exception.body(), exception.status());
     }
 
-
+    @ExceptionHandler(PerformanceAlreadyProcessedException.class)
+    public ResponseEntity<ApiResult<?>> performanceAlreadyProcessedException(
+            PerformanceAlreadyProcessedException exception) {
+        return new ResponseEntity<>(exception.body(), exception.status());
+    }
 }

--- a/src/main/java/com/prography/lighton/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/lighton/common/exception/GlobalExceptionHandler.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
-@Order(10)
+@Order(2)
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 

--- a/src/main/java/com/prography/lighton/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/prography/lighton/common/exception/GlobalExceptionHandler.java
@@ -8,12 +8,12 @@ import com.prography.lighton.common.exception.base.NotFoundException;
 import com.prography.lighton.common.exception.base.UnsupportedTypeException;
 import com.prography.lighton.common.utils.ApiUtils;
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
-import com.prography.lighton.performance.admin.application.exception.PerformanceAlreadyProcessedException;
 import com.prography.lighton.performance.common.domain.exception.MasterArtistCannotBeRemovedException;
 import com.prography.lighton.performance.common.domain.exception.PerformanceNotApprovedException;
 import com.prography.lighton.performance.common.domain.exception.PerformanceUpdateNotAllowedException;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j
+@Order(10)
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
@@ -108,9 +109,4 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(exception.body(), exception.status());
     }
 
-    @ExceptionHandler(PerformanceAlreadyProcessedException.class)
-    public ResponseEntity<ApiResult<?>> performanceAlreadyProcessedException(
-            PerformanceAlreadyProcessedException exception) {
-        return new ResponseEntity<>(exception.body(), exception.status());
-    }
 }

--- a/src/main/java/com/prography/lighton/performance/admin/application/exception/PerformanceAlreadyProcessedException.java
+++ b/src/main/java/com/prography/lighton/performance/admin/application/exception/PerformanceAlreadyProcessedException.java
@@ -1,0 +1,18 @@
+package com.prography.lighton.performance.admin.application.exception;
+
+import com.prography.lighton.common.utils.ApiUtils;
+import org.springframework.http.HttpStatus;
+
+public class PerformanceAlreadyProcessedException extends RuntimeException {
+
+    private final String message = "해당 공연은 현재 승인 및 반려 할 수 없는 상태입니다.";
+
+    public ApiUtils.ApiResult<?> body() {
+        return ApiUtils.error(HttpStatus.BAD_REQUEST, message);
+    }
+
+    public HttpStatus status() {
+        return HttpStatus.BAD_REQUEST;
+    }
+
+}

--- a/src/main/java/com/prography/lighton/performance/admin/application/impl/PerformanceApplicationQueryUseCaseImpl.java
+++ b/src/main/java/com/prography/lighton/performance/admin/application/impl/PerformanceApplicationQueryUseCaseImpl.java
@@ -4,13 +4,13 @@ import static com.prography.lighton.performance.common.domain.entity.enums.Appro
 import static com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus.REJECTED;
 
 import com.prography.lighton.performance.admin.application.PerformanceApplicationQueryUseCase;
+import com.prography.lighton.performance.admin.application.exception.PerformanceAlreadyProcessedException;
 import com.prography.lighton.performance.admin.application.mapper.PendingPerformanceMapper;
 import com.prography.lighton.performance.admin.infrastructure.repository.AdminPerformanceRepository;
 import com.prography.lighton.performance.admin.presentation.dto.response.GetPerformanceApplicationDetailResponseDTO;
 import com.prography.lighton.performance.admin.presentation.dto.response.GetPerformanceApplicationListResponseDTO;
 import com.prography.lighton.performance.common.domain.entity.Performance;
 import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
-import com.prography.lighton.performance.common.domain.exception.NoSuchPerformanceException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -47,9 +47,15 @@ public class PerformanceApplicationQueryUseCaseImpl implements PerformanceApplic
 
     @Override
     public GetPerformanceApplicationDetailResponseDTO getPendingPerformanceDetail(Long performanceId) {
-        Performance performance = adminPerformanceRepository.findByIdAndApproveStatus(performanceId, PENDING)
-                .orElseThrow(() -> new NoSuchPerformanceException("해당 공연은 이미 처리 되었거나 존재하지 않습니다."));
+        Performance performance = adminPerformanceRepository.getById(performanceId);
+        validateIsVisibleOnAdminPage(performance);
 
         return pendingPerformanceMapper.toPendingPerformanceDetailResponseDTO(performance);
+    }
+
+    private void validateIsVisibleOnAdminPage(Performance performance) {
+        if (!performance.isVisibleOnAdminPage()) {
+            throw new PerformanceAlreadyProcessedException();
+        }
     }
 }

--- a/src/main/java/com/prography/lighton/performance/admin/application/impl/PerformanceApplicationQueryUseCaseImpl.java
+++ b/src/main/java/com/prography/lighton/performance/admin/application/impl/PerformanceApplicationQueryUseCaseImpl.java
@@ -4,7 +4,6 @@ import static com.prography.lighton.performance.common.domain.entity.enums.Appro
 import static com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus.REJECTED;
 
 import com.prography.lighton.performance.admin.application.PerformanceApplicationQueryUseCase;
-import com.prography.lighton.performance.admin.application.exception.PerformanceAlreadyProcessedException;
 import com.prography.lighton.performance.admin.application.mapper.PendingPerformanceMapper;
 import com.prography.lighton.performance.admin.infrastructure.repository.AdminPerformanceRepository;
 import com.prography.lighton.performance.admin.presentation.dto.response.GetPerformanceApplicationDetailResponseDTO;
@@ -48,14 +47,10 @@ public class PerformanceApplicationQueryUseCaseImpl implements PerformanceApplic
     @Override
     public GetPerformanceApplicationDetailResponseDTO getPendingPerformanceDetail(Long performanceId) {
         Performance performance = adminPerformanceRepository.getById(performanceId);
-        validateIsVisibleOnAdminPage(performance);
+        performance.validateIsVisibleOnAdminPage();
 
         return pendingPerformanceMapper.toPendingPerformanceDetailResponseDTO(performance);
     }
 
-    private void validateIsVisibleOnAdminPage(Performance performance) {
-        if (!performance.isVisibleOnAdminPage()) {
-            throw new PerformanceAlreadyProcessedException();
-        }
-    }
+
 }

--- a/src/main/java/com/prography/lighton/performance/admin/infrastructure/repository/AdminPerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/admin/infrastructure/repository/AdminPerformanceRepository.java
@@ -2,6 +2,7 @@ package com.prography.lighton.performance.admin.infrastructure.repository;
 
 import com.prography.lighton.performance.common.domain.entity.Performance;
 import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
+import com.prography.lighton.performance.common.domain.exception.NoSuchPerformanceException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Page;
@@ -50,4 +51,8 @@ public interface AdminPerformanceRepository extends JpaRepository<Performance, L
     Long countEndedByApproveStatus(
             @Param("approveStatus") ApproveStatus approveStatus
     );
+
+    default Performance getById(Long performanceId) {
+        return findById(performanceId).orElseThrow(NoSuchPerformanceException::new);
+    }
 }

--- a/src/main/java/com/prography/lighton/performance/admin/presentation/exception/AdminPerformanceExceptionHandler.java
+++ b/src/main/java/com/prography/lighton/performance/admin/presentation/exception/AdminPerformanceExceptionHandler.java
@@ -1,0 +1,17 @@
+package com.prography.lighton.performance.admin.presentation.exception;
+
+import com.prography.lighton.common.utils.ApiUtils.ApiResult;
+import com.prography.lighton.performance.admin.application.exception.PerformanceAlreadyProcessedException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class AdminPerformanceExceptionHandler {
+
+    @ExceptionHandler(PerformanceAlreadyProcessedException.class)
+    public ResponseEntity<ApiResult<?>> performanceAlreadyProcessedException(
+            PerformanceAlreadyProcessedException exception) {
+        return new ResponseEntity<>(exception.body(), exception.status());
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/admin/presentation/exception/AdminPerformanceExceptionHandler.java
+++ b/src/main/java/com/prography/lighton/performance/admin/presentation/exception/AdminPerformanceExceptionHandler.java
@@ -2,11 +2,13 @@ package com.prography.lighton.performance.admin.presentation.exception;
 
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
 import com.prography.lighton.performance.admin.application.exception.PerformanceAlreadyProcessedException;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @RestControllerAdvice
+@Order(1)
 public class AdminPerformanceExceptionHandler {
 
     @ExceptionHandler(PerformanceAlreadyProcessedException.class)

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
@@ -342,8 +342,10 @@ public class Performance extends BaseEntity {
         }
     }
 
-    public boolean isVisibleOnAdminPage() {
-        return this.approveStatus == ApproveStatus.PENDING || this.approveStatus == ApproveStatus.REJECTED;
+    public void validateIsVisibleOnAdminPage() {
+        if (!(this.approveStatus == ApproveStatus.PENDING || this.approveStatus == ApproveStatus.REJECTED)) {
+            throw new InvalidApproveStatusTransitionException();
+        }
     }
 
 }

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
@@ -341,4 +341,9 @@ public class Performance extends BaseEntity {
             this.likeCount--;
         }
     }
+
+    public boolean isVisibleOnAdminPage() {
+        return this.approveStatus == ApproveStatus.PENDING || this.approveStatus == ApproveStatus.REJECTED;
+    }
+
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #51 

## 🔧 작업 내용
- 공연 신청 내역 조회 시, 대기 상태 외의 공연도 보이도록 로직 수정 
- 예외 핸들러 클래스 적용 순서 지정 (제대로 작동은 되긴 합니다! 혹시나 코드 개선점이 보인다면 말씀해주세요!)
    - 글로벌 예외 핸들러는 공통 핸들러니까 적용 순서를 10으로 지정했습니다.
    - 특정 예외 핸들러들이 우선순위 1~5에 배치되더라도 충돌 없이 동작하도록 여유 있게 잡았습니다. 

```json
{
    "success": false,
    "response": null,
    "error": {
        "status": 400,
        "message": "해당 공연은 현재 승인 및 반려 할 수 없는 상태입니다."
    }
}
```
## 💬 기타 사항
