### PR TITLE
[Refactor] 선호 장르 조회 API 엔드포인트 수정

### DIFF
--- a/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCase.java
+++ b/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCase.java
@@ -6,7 +6,7 @@ import com.prography.lighton.member.users.presentation.dto.response.GetPreferred
 
 public interface ManagePreferredGenreUseCase {
 
-    void editMemberGenre(final Long memberId, final EditMemberGenreRequestDTO request);
+    void editMemberGenre(final Member member, final EditMemberGenreRequestDTO request);
 
     GetPreferredGenreResponseDTO getPreferredGenre(final Member member);
 }

--- a/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCaseImpl.java
+++ b/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCaseImpl.java
@@ -5,7 +5,6 @@ import com.prography.lighton.genre.infrastructure.cache.GenreCache;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.member.common.domain.entity.association.PreferredGenre;
 import com.prography.lighton.member.presentation.dto.request.EditMemberGenreRequestDTO;
-import com.prography.lighton.member.users.infrastructure.repository.MemberRepository;
 import com.prography.lighton.member.users.infrastructure.repository.PreferredGenreRepository;
 import com.prography.lighton.member.users.presentation.dto.response.GetPreferredGenreResponseDTO;
 import java.util.List;
@@ -18,16 +17,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ManagePreferredGenreUseCaseImpl implements ManagePreferredGenreUseCase {
 
-    private final MemberRepository memberRepository;
     private final PreferredGenreRepository preferredGenreRepository;
 
     private final GenreCache genreCache;
 
     @Override
     @Transactional
-    public void editMemberGenre(Long memberId, EditMemberGenreRequestDTO request) {
-        Member member = memberRepository.getMemberById(memberId);
-        deletePreviousPreferredGenres(memberId);
+    public void editMemberGenre(final Member member, EditMemberGenreRequestDTO request) {
+        deletePreviousPreferredGenres(member);
 
         List<PreferredGenre> preferredGenres = genreCache.getGenresByNameOrThrow(request.genres()).stream()
                 .map((genre -> PreferredGenre.of(member, genre)))
@@ -46,7 +43,7 @@ public class ManagePreferredGenreUseCaseImpl implements ManagePreferredGenreUseC
         return GetPreferredGenreResponseDTO.of(genres);
     }
 
-    private void deletePreviousPreferredGenres(Long memberId) {
-        preferredGenreRepository.deleteAllByMemberId(memberId);
+    private void deletePreviousPreferredGenres(Member member) {
+        preferredGenreRepository.deleteAllByMember(member);
     }
 }

--- a/src/main/java/com/prography/lighton/member/users/infrastructure/repository/PreferredGenreRepository.java
+++ b/src/main/java/com/prography/lighton/member/users/infrastructure/repository/PreferredGenreRepository.java
@@ -11,5 +11,5 @@ public interface PreferredGenreRepository extends JpaRepository<PreferredGenre, 
 
     List<PreferredGenre> findAllByMember(Member member);
 
-    void deleteAllByMemberId(Long memberId);
+    void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/prography/lighton/member/users/presentation/MemberController.java
+++ b/src/main/java/com/prography/lighton/member/users/presentation/MemberController.java
@@ -1,6 +1,5 @@
 package com.prography.lighton.member.users.presentation;
 
-import com.prography.lighton.auth.security.util.SecurityUtils;
 import com.prography.lighton.common.annotation.LoginMember;
 import com.prography.lighton.common.utils.ApiUtils;
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
@@ -54,8 +53,9 @@ public class MemberController {
 
     @PostMapping("/genres")
     public ResponseEntity<ApiResult<?>> editMemberGenre(
-            @RequestBody @Valid com.prography.lighton.member.presentation.dto.request.EditMemberGenreRequestDTO request) {
-        managePreferredGenreUseCase.editMemberGenre(SecurityUtils.getCurrentMemberId(), request);
+            @RequestBody @Valid com.prography.lighton.member.presentation.dto.request.EditMemberGenreRequestDTO request,
+            @LoginMember Member member) {
+        managePreferredGenreUseCase.editMemberGenre(member, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ApiUtils.success());
     }
 


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #73 

## 🔧 작업 내용
- 선호 장르 조회 API 엔드포인트 내 회원 식별자를 Path Variable로 받는 상황
- 토큰을 통해 회원 식별 하도록 변경

## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified the endpoint for retrieving a member's preferred genres; now automatically uses the currently logged-in member without requiring a member ID in the URL.

* **Refactor**
  * Improved handling of member information by passing the member entity directly throughout the preferred genre retrieval process, enhancing consistency and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->