### PR TITLE
[Feature] 사용자 - 회원 탈퇴 

### DIFF
--- a/src/main/java/com/prography/lighton/artist/users/application/service/ArtistService.java
+++ b/src/main/java/com/prography/lighton/artist/users/application/service/ArtistService.java
@@ -85,6 +85,10 @@ public class ArtistService {
         );
     }
 
+    public void inactiveByMember(Member member) {
+        artistRepository.deleteByMember(member);
+    }
+
     public ArtistCheckResponseDTO isArtist(Member member) {
         return ArtistCheckResponseDTO.of(
                 artistRepository.existsByMemberAndApproveStatus(member, ApproveStatus.APPROVED));

--- a/src/main/java/com/prography/lighton/artist/users/infrastructure/repository/ArtistRepository.java
+++ b/src/main/java/com/prography/lighton/artist/users/infrastructure/repository/ArtistRepository.java
@@ -17,6 +17,8 @@ public interface ArtistRepository extends JpaRepository<Artist, Long> {
 
     Optional<Artist> findByMember(Member member);
 
+    void deleteByMember(Member member);
+
     @Query("""
                 select a from Artist a
                 join fetch a.genres ag

--- a/src/main/java/com/prography/lighton/artist/users/infrastructure/repository/ArtistRepository.java
+++ b/src/main/java/com/prography/lighton/artist/users/infrastructure/repository/ArtistRepository.java
@@ -6,6 +6,7 @@ import com.prography.lighton.artist.users.application.exception.NoSuchArtistExce
 import com.prography.lighton.member.common.domain.entity.Member;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -17,6 +18,7 @@ public interface ArtistRepository extends JpaRepository<Artist, Long> {
 
     Optional<Artist> findByMember(Member member);
 
+    @Modifying
     void deleteByMember(Member member);
 
     @Query("""

--- a/src/main/java/com/prography/lighton/auth/application/AuthService.java
+++ b/src/main/java/com/prography/lighton/auth/application/AuthService.java
@@ -10,6 +10,8 @@ public interface AuthService {
 
     void logout(Member member);
 
+    void withdraw(Member member);
+
     void sendAuthCode(String phoneNumber);
 
     void verifyPhone(VerifyPhoneRequestDTO request);

--- a/src/main/java/com/prography/lighton/auth/application/impl/AuthServiceImpl.java
+++ b/src/main/java/com/prography/lighton/auth/application/impl/AuthServiceImpl.java
@@ -65,7 +65,7 @@ public class AuthServiceImpl implements AuthService {
     @Transactional
     public void withdraw(Member member) {
         Member dbMember = memberRepository.getMemberById(member.getId());
-        dbMember.withdraw();
+        member.withdraw();
         memberRepository.flush();
 
         userPerformanceService.inactivateAllByMember(dbMember);

--- a/src/main/java/com/prography/lighton/auth/application/impl/AuthServiceImpl.java
+++ b/src/main/java/com/prography/lighton/auth/application/impl/AuthServiceImpl.java
@@ -12,6 +12,7 @@ import com.prography.lighton.auth.presentation.dto.request.VerifyPhoneRequestDTO
 import com.prography.lighton.auth.presentation.dto.response.ReissueTokenResponse;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.member.users.application.ManagePreferredGenreUseCase;
+import com.prography.lighton.member.users.infrastructure.repository.TemporaryMemberRepository;
 import com.prography.lighton.performance.users.application.service.UserPerformanceLikeService;
 import com.prography.lighton.performance.users.application.service.UserPerformanceService;
 import lombok.RequiredArgsConstructor;
@@ -24,6 +25,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AuthServiceImpl implements AuthService {
 
     private final static String ROLE_KEY = "roles";
+
+    private final TemporaryMemberRepository temporaryMemberRepository;
 
     private final TokenProvider tokenProvider;
     private final RefreshTokenService refreshTokenService;
@@ -65,7 +68,8 @@ public class AuthServiceImpl implements AuthService {
         userPerformanceLikeService.inactivateAllByMember(member);
         artistService.inactiveByMember(member);
 
-        member.delete();
+        temporaryMemberRepository.deleteByEmail(member.getEmail());
+        member.withdraw();
     }
 
     @Override

--- a/src/main/java/com/prography/lighton/auth/presentation/AuthController.java
+++ b/src/main/java/com/prography/lighton/auth/presentation/AuthController.java
@@ -24,6 +24,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -80,6 +81,13 @@ public class AuthController {
     public ResponseEntity<ApiResult<String>> logout(@LoginMember Member member) {
         authService.logout(member);
         return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiUtils.success());
+    }
+
+    @DeleteMapping("/auth/me")
+    public ResponseEntity<ApiResult<String>> withdraw(@LoginMember Member member) {
+        authService.withdraw(member);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT)
                 .body(ApiUtils.success());
     }
 

--- a/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
+++ b/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
@@ -43,6 +43,9 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/members/*/info").permitAll()
                         .requestMatchers("/api/oauth/**").permitAll()
                         .requestMatchers("api/admin/**").hasRole("ADMIN")
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances/popular").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances/nearby").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances").permitAll()
 
                         // Swagger & OpenAPI
                         .requestMatchers(

--- a/src/main/java/com/prography/lighton/common/config/SwaggerConfig.java
+++ b/src/main/java/com/prography/lighton/common/config/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.prography.lighton.common.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String SECURITY_SCHEME_NAME = "Bearer Authentication";
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes(SECURITY_SCHEME_NAME,
+                                new SecurityScheme()
+                                        .name("Authorization")
+                                        .type(SecurityScheme.Type.HTTP)
+                                        .scheme("bearer")
+                                        .bearerFormat("JWT")
+                        ))
+                .addSecurityItem(new SecurityRequirement().addList(SECURITY_SCHEME_NAME))
+                .info(new Info()
+                        .title("Light-ON API")
+                        .version("v1")
+                        .description("라이트 온 프로젝트의 API 문서입니다."));
+    }
+}

--- a/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
+++ b/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
@@ -12,6 +12,9 @@ public final class SecurityWhitelist {
             "/api/auth/token/refresh",
             "/api/auth/phones/code",
             "/api/auth/phones/code/verify",
+            "/api/members/performances",
+            "/api/members/performances/nearby",
+            "/api/members/performances/popular",
     };
 
     // 접두사로 매칭되는 경로들
@@ -21,7 +24,7 @@ public final class SecurityWhitelist {
             "/docs",
             "/swagger-resources",
             "/webjars",
-            "/api/oauth"
+            "/api/oauth",
     };
 
     // 정규식으로 매칭되는 경로들

--- a/src/main/java/com/prography/lighton/member/common/domain/entity/Member.java
+++ b/src/main/java/com/prography/lighton/member/common/domain/entity/Member.java
@@ -107,12 +107,8 @@ public class Member extends BaseEntity {
     }
 
     public void withdraw() {
-        if (!isStatus()) {
-            return;
-        }
-
-        this.phone.withdrawMasked(this.getId());
-        this.email.withdrawMasked(this.getId());
+        this.phone = this.phone.withdrawMasked(this.getId());
+        this.email = this.email.withdrawMasked(this.getId());
         this.delete();
     }
 }

--- a/src/main/java/com/prography/lighton/member/common/domain/entity/Member.java
+++ b/src/main/java/com/prography/lighton/member/common/domain/entity/Member.java
@@ -105,4 +105,14 @@ public class Member extends BaseEntity {
         this.preferredGenres.clear();
         this.preferredGenres.addAll(preferredGenres);
     }
+
+    public void withdraw() {
+        if (!isStatus()) {
+            return;
+        }
+
+        this.phone.withdrawMasked(this.getId());
+        this.email.withdrawMasked(this.getId());
+        this.delete();
+    }
 }

--- a/src/main/java/com/prography/lighton/member/common/domain/entity/vo/Email.java
+++ b/src/main/java/com/prography/lighton/member/common/domain/entity/vo/Email.java
@@ -20,6 +20,7 @@ import lombok.NoArgsConstructor;
 public class Email {
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile("^[\\w-.]+@([\\w-]+\\.)+[\\w-]{2,4}$");
+    private static final String MASKED_EMAIL_SUFFIX = "_DELETED_";
 
     @Column(nullable = false, name = "email")
     private String value;
@@ -30,4 +31,9 @@ public class Email {
         }
         return new Email(value);
     }
+
+    public Email withdrawMasked(Long memberId) {
+        return new Email(this.value + MASKED_EMAIL_SUFFIX + memberId);
+    }
+
 }

--- a/src/main/java/com/prography/lighton/member/common/domain/entity/vo/Phone.java
+++ b/src/main/java/com/prography/lighton/member/common/domain/entity/vo/Phone.java
@@ -16,8 +16,9 @@ import lombok.NoArgsConstructor;
 public class Phone {
 
     private static final String PHONE_NUMBER_PATTERN = "^\\d{3}\\d{3,4}\\d{4}$";
+    private static final String MASKED_PHONE_SUFFIX = "_DELETED_";
 
-    @Column(nullable = false, length = 20, unique = true, name = "phone")
+    @Column(nullable = false, length = 30, unique = true, name = "phone")
     private String value;
 
     public static Phone of(String phoneNumber) {
@@ -25,5 +26,9 @@ public class Phone {
             throw new IllegalArgumentException("전화번호 형식이 올바르지 않습니다.");
         }
         return new Phone(phoneNumber);
+    }
+
+    public Phone withdrawMasked(Long memberId) {
+        return new Phone(this.value + MASKED_PHONE_SUFFIX + memberId);
     }
 }

--- a/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCase.java
+++ b/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCase.java
@@ -9,4 +9,6 @@ public interface ManagePreferredGenreUseCase {
     void editMemberGenre(final Member member, final EditMemberGenreRequestDTO request);
 
     GetPreferredGenreResponseDTO getPreferredGenre(final Member member);
+
+    void inactivateAllByMember(final Member member);
 }

--- a/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCaseImpl.java
+++ b/src/main/java/com/prography/lighton/member/users/application/ManagePreferredGenreUseCaseImpl.java
@@ -43,6 +43,11 @@ public class ManagePreferredGenreUseCaseImpl implements ManagePreferredGenreUseC
         return GetPreferredGenreResponseDTO.of(genres);
     }
 
+    @Override
+    public void inactivateAllByMember(Member member) {
+        deletePreviousPreferredGenres(member);
+    }
+
     private void deletePreviousPreferredGenres(Member member) {
         preferredGenreRepository.deleteAllByMember(member);
     }

--- a/src/main/java/com/prography/lighton/member/users/infrastructure/repository/PreferredGenreRepository.java
+++ b/src/main/java/com/prography/lighton/member/users/infrastructure/repository/PreferredGenreRepository.java
@@ -4,6 +4,7 @@ import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.member.common.domain.entity.association.PreferredGenre;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -11,5 +12,6 @@ public interface PreferredGenreRepository extends JpaRepository<PreferredGenre, 
 
     List<PreferredGenre> findAllByMember(Member member);
 
+    @Modifying
     void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/prography/lighton/member/users/infrastructure/repository/TemporaryMemberRepository.java
+++ b/src/main/java/com/prography/lighton/member/users/infrastructure/repository/TemporaryMemberRepository.java
@@ -13,6 +13,8 @@ public interface TemporaryMemberRepository extends JpaRepository<TemporaryMember
 
     Optional<TemporaryMember> findByEmail(Email email);
 
+    void deleteByEmail(Email email);
+
     @Query("SELECT COUNT(m) > 0 FROM TemporaryMember m WHERE m.email.value = :email AND not m.isRegistered")
     boolean existsByEmailAndNotRegistered(@Param("email") String email);
 

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Busking.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Busking.java
@@ -21,12 +21,16 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 
 @Entity
 @DiscriminatorValue("BUSKING")
 @Getter
 @NoArgsConstructor(access = PROTECTED)
 @AllArgsConstructor(access = PRIVATE)
+@SQLDelete(sql = "UPDATE performance SET status = false WHERE id = ?")
+@SQLRestriction("status = true")
 public class Busking extends Performance {
 
     private static final int UPDATE_DEADLINE_DAYS = 3;

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
@@ -396,4 +396,8 @@ public class Performance extends BaseEntity {
             throw new NotAuthorizedPerformanceException();
         }
     }
+
+    public void inactivate() {
+        this.canceled = true;
+    }
 }

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/PerformanceRequest.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/PerformanceRequest.java
@@ -52,4 +52,9 @@ public class PerformanceRequest extends BaseEntity {
         this.requestStatus = requestStatus;
     }
 
+    public void inactivate() {
+        this.requestStatus = RequestStatus.REJECTED;
+    }
+
+
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceLikeService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceLikeService.java
@@ -29,5 +29,9 @@ public class UserPerformanceLikeService {
         performanceLikeRepository.save(like);
         return LikePerformanceResponse.of(nowLiked);
     }
+
+    public void inactivateAllByMember(Member member) {
+        performanceLikeRepository.deleteAllByMember(member);
+    }
 }
 

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
@@ -16,6 +16,7 @@ import com.prography.lighton.region.domain.entity.SubRegion;
 import com.prography.lighton.region.infrastructure.cache.RegionCache;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -66,14 +67,13 @@ public class UserPerformanceService {
         performanceRequestRepository.delete(performanceRequest);
     }
 
+    @Transactional
     public void inactivateAllByMember(Member member) {
-        performanceRepository.findAllByPerformer(member).
-                forEach(Performance::inactivate);
+        List<Performance> performances = performanceRepository.findAllByPerformer(member);
+        performances.forEach(Performance::inactivate);
 
-        performanceRequestRepository.findAllByMember(member)
-                .forEach(PerformanceRequest::inactivate);
-
-        performanceRepository.deleteAllByPerformer(member);
+        performanceRequestRepository.bulkInactivateByMember(member);
+        performanceRequestRepository.bulkInactivateByPerformances(performances);
     }
 
     public GetMyRegisteredPerformanceListResponseDTO getMyRegisteredPerformanceList(Member member) {

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
@@ -16,7 +16,6 @@ import com.prography.lighton.region.domain.entity.SubRegion;
 import com.prography.lighton.region.infrastructure.cache.RegionCache;
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -68,10 +67,11 @@ public class UserPerformanceService {
     }
 
     public void inactivateAllByMember(Member member) {
-        List<Performance> performances = performanceRepository.findAllByPerformer(member);
+        performanceRepository.findAllByPerformer(member).
+                forEach(Performance::inactivate);
 
-        performanceRequestRepository.deleteAllByMember(member);
-        performanceRequestRepository.deleteAllByPerformances(performances);
+        performanceRequestRepository.findAllByMember(member)
+                .forEach(PerformanceRequest::inactivate);
 
         performanceRepository.deleteAllByPerformer(member);
     }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
@@ -16,6 +16,7 @@ import com.prography.lighton.region.domain.entity.SubRegion;
 import com.prography.lighton.region.infrastructure.cache.RegionCache;
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -64,6 +65,15 @@ public class UserPerformanceService {
 
         performance.cancelRequest(performanceRequest.getRequestedSeats());
         performanceRequestRepository.delete(performanceRequest);
+    }
+
+    public void inactivateAllByMember(Member member) {
+        List<Performance> performances = performanceRepository.findAllByPerformer(member);
+
+        performanceRequestRepository.deleteAllByMember(member);
+        performanceRequestRepository.deleteAllByPerformances(performances);
+
+        performanceRepository.deleteAllByPerformer(member);
     }
 
     public GetMyRegisteredPerformanceListResponseDTO getMyRegisteredPerformanceList(Member member) {

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLikeRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLikeRepository.java
@@ -5,6 +5,7 @@ import com.prography.lighton.performance.common.domain.entity.Performance;
 import com.prography.lighton.performance.common.domain.entity.PerformanceLike;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
 public interface PerformanceLikeRepository extends JpaRepository<PerformanceLike, Long> {
 
@@ -12,6 +13,8 @@ public interface PerformanceLikeRepository extends JpaRepository<PerformanceLike
 
     boolean existsByMemberAndPerformance(Member member, Performance performance);
 
+
+    @Modifying
     void deleteAllByMember(Member member);
 
 }

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLikeRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLikeRepository.java
@@ -11,5 +11,8 @@ public interface PerformanceLikeRepository extends JpaRepository<PerformanceLike
     Optional<PerformanceLike> findByMemberAndPerformance(Member member, Performance performance);
 
     boolean existsByMemberAndPerformance(Member member, Performance performance);
+
+    void deleteAllByMember(Member member);
+
 }
 

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -37,6 +38,8 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 
     List<Performance> findAllByPerformer(Member performer);
 
+
+    @Modifying
     void deleteAllByPerformer(Member performer);
 
     default Busking getByBuskingId(Long id) {

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
@@ -35,6 +35,10 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     @Query("SELECT p FROM Busking p WHERE p.id = :id")
     Optional<Busking> findBuskingById(@Param("id") Long id);
 
+    List<Performance> findAllByPerformer(Member performer);
+
+    void deleteAllByPerformer(Member performer);
+
     default Busking getByBuskingId(Long id) {
         return findBuskingById(id)
                 .orElseThrow(NoSuchPerformanceException::new);

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
@@ -22,12 +22,7 @@ public interface PerformanceRequestRepository extends JpaRepository<PerformanceR
 
     Optional<PerformanceRequest> findByMemberAndPerformance(Member member, Performance performance);
 
-    @Modifying(clearAutomatically = true)
-    void deleteAllByMember(Member member);
-
-    @Modifying(clearAutomatically = true)
-    @Query("UPDATE PerformanceRequest pr SET pr.status = false WHERE pr.performance IN :performances")
-    void deleteAllByPerformances(@Param("performances") List<Performance> performances);
+    List<PerformanceRequest> findAllByMember(Member member);
 
     default PerformanceRequest getByMemberAndPerformance(Member member, Performance performance) {
         return findByMemberAndPerformance(member, performance)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
@@ -8,7 +8,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -22,6 +21,12 @@ public interface PerformanceRequestRepository extends JpaRepository<PerformanceR
     boolean existsByMemberAndPerformance(Member member, Performance performance);
 
     Optional<PerformanceRequest> findByMemberAndPerformance(Member member, Performance performance);
+
+    void deleteAllByMember(Member member);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE PerformanceRequest pr SET pr.status = false WHERE pr.performance IN :performances")
+    void deleteAllByPerformances(@Param("performances") List<Performance> performances);
 
     default PerformanceRequest getByMemberAndPerformance(Member member, Performance performance) {
         return findByMemberAndPerformance(member, performance)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
@@ -24,6 +24,14 @@ public interface PerformanceRequestRepository extends JpaRepository<PerformanceR
 
     List<PerformanceRequest> findAllByMember(Member member);
 
+    @Modifying
+    @Query("UPDATE PerformanceRequest pr SET pr.requestStatus = 'REJECTED' WHERE pr.member = :member")
+    void bulkInactivateByMember(@Param("member") Member member);
+
+    @Modifying
+    @Query("UPDATE PerformanceRequest pr SET pr.requestStatus = 'REJECTED' WHERE pr.performance IN :performances")
+    void bulkInactivateByPerformances(@Param("performances") List<Performance> performances);
+
     default PerformanceRequest getByMemberAndPerformance(Member member, Performance performance) {
         return findByMemberAndPerformance(member, performance)
                 .orElseThrow(NoSuchPerformanceRequestException::new);

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
@@ -22,6 +22,7 @@ public interface PerformanceRequestRepository extends JpaRepository<PerformanceR
 
     Optional<PerformanceRequest> findByMemberAndPerformance(Member member, Performance performance);
 
+    @Modifying(clearAutomatically = true)
     void deleteAllByMember(Member member);
 
     @Modifying(clearAutomatically = true)


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #82 

## 🔧 작업 내용
- 회원 탈퇴 기능 구현
- 관련된 공연, 공연 신청, 아티스트 등록, 선호 장르 등 연관 데이터 함께 비활성화

## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user withdrawal (account deletion) endpoint, allowing users to delete their accounts via a DELETE request to `/auth/me`.
  * Upon withdrawal, all user-related data such as performances, performance likes, preferred genres, artist records, and temporary member data are automatically removed or inactivated.
  * User contact information is masked during withdrawal to protect privacy.
  * Public access enabled for member performance-related endpoints without authentication.
  * Introduced API documentation with OpenAPI (Swagger) including JWT Bearer Authentication scheme.
  * Soft delete behavior added for busking records to improve data management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->