### PR TITLE
[Feature] 사용자 - 최신 공연 조회 API

### DIFF
--- a/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
+++ b/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
@@ -45,6 +45,7 @@ public class SecurityConfig {
                         .requestMatchers("api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/popular").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/nearby").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances/recent").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances").permitAll()
 
                         // Swagger & OpenAPI

--- a/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
+++ b/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/auth/phones/code/verify").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/auth/login").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/duplicate-check").permitAll()
-                        .requestMatchers(HttpMethod.POST, "/api/members/{temporaryMemberId}/info").permitAll()
+                        .requestMatchers(HttpMethod.POST, "/api/members/*/info").permitAll()
                         .requestMatchers("/api/admin/**").hasRole("ADMIN")
                         .requestMatchers(HttpMethod.POST, "/api/members/*/info").permitAll()
                         .requestMatchers("/api/oauth/**").permitAll()
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/nearby").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/recent").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances/*").permitAll()
 
                         // Swagger & OpenAPI
                         .requestMatchers(

--- a/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
+++ b/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
@@ -30,7 +30,8 @@ public final class SecurityWhitelist {
 
     // 정규식으로 매칭되는 경로들
     public static final String[] REGEX_MATCH = {
-            "^/api/members/\\d+/info$"
+            "^/api/members/\\d+/info$",
+            "^/api/members/performances/\\d+$"
     };
 
     private SecurityWhitelist() {

--- a/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
+++ b/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
@@ -15,6 +15,7 @@ public final class SecurityWhitelist {
             "/api/members/performances",
             "/api/members/performances/nearby",
             "/api/members/performances/popular",
+            "/api/members/performances/recent",
     };
 
     // 접두사로 매칭되는 경로들

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserRecentPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserRecentPerformanceService.java
@@ -1,0 +1,37 @@
+package com.prography.lighton.performance.users.application.service;
+
+import com.prography.lighton.performance.users.application.resolver.PerformanceListHelper;
+import com.prography.lighton.performance.users.infrastructure.repository.RecentPerformanceRepository;
+import com.prography.lighton.performance.users.presentation.dto.response.GetPerformanceBrowseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserRecentPerformanceService {
+
+    private static final int LIMIT = 30;
+    private static final String RECENT_CACHE_KEY_PREFIX = "recent:";
+    private static final String ALL_GENRE_KEY = "all";
+
+    private final PerformanceListHelper helper;
+    private final RecentPerformanceRepository recentPerformanceRepository;
+
+    public GetPerformanceBrowseResponse getRecentPerformances(String genreName) {
+        String key = buildKey(genreName);
+        return helper.fetchWithCache(
+                key,
+                () -> recentPerformanceRepository.findRecentIds(genreName, LIMIT)
+        );
+    }
+
+    private String buildKey(String genre) {
+        String normalizeGenre = StringUtils.hasText(genre) ? genre.toLowerCase() : ALL_GENRE_KEY;
+        return RECENT_CACHE_KEY_PREFIX + normalizeGenre;
+    }
+
+
+}

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformancePopularRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformancePopularRepositoryImpl.java
@@ -27,7 +27,8 @@ public class PerformancePopularRepositoryImpl implements PerformancePopularRepos
                 .where(
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.schedule.endDate.goe(today),
-                        p.status.isTrue()
+                        p.status.isTrue(),
+                        p.canceled.isFalse()
                 )
                 .orderBy(p.likeCount.desc(), p.viewCount.desc())
                 .limit(limit)
@@ -51,6 +52,7 @@ public class PerformancePopularRepositoryImpl implements PerformancePopularRepos
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.schedule.endDate.goe(today),
                         p.status.isTrue(),
+                        p.canceled.isFalse(),
                         g.name.eq(genre)
                 )
                 .orderBy(p.likeCount.desc(), p.viewCount.desc())

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRecommendationRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRecommendationRepositoryImpl.java
@@ -33,7 +33,8 @@ public class PerformanceRecommendationRepositoryImpl implements PerformanceRecom
                         mpg.member.id.eq(memberId),
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.schedule.endDate.goe(LocalDate.now()),
-                        p.status.eq(true)
+                        p.status.eq(true),
+                        p.canceled.isFalse()
                 )
                 .groupBy(p.id)
                 .orderBy(

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
@@ -13,7 +13,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
-import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -37,10 +36,6 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     Optional<Busking> findBuskingById(@Param("id") Long id);
 
     List<Performance> findAllByPerformer(Member performer);
-
-
-    @Modifying
-    void deleteAllByPerformer(Member performer);
 
     default Busking getByBuskingId(Long id) {
         return findBuskingById(id)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceSummaryRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceSummaryRepositoryImpl.java
@@ -50,7 +50,8 @@ public class PerformanceSummaryRepositoryImpl implements PerformanceSummaryRepos
                 .on(sr.id.eq(subRegionIdPath))
                 .where(
                         perf.getNumber("id", Long.class).in(ids),
-                        perf.getBoolean("status").eq(true)
+                        perf.getBoolean("status").eq(true),
+                        perf.getBoolean("canceled").eq(false)
                 )
                 .transform(
                         groupBy(perf.getNumber("id", Long.class)).list(

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepository.java
@@ -1,0 +1,18 @@
+package com.prography.lighton.performance.users.infrastructure.repository;
+
+import java.util.List;
+import org.springframework.util.StringUtils;
+
+public interface RecentPerformanceRepository {
+
+    List<Long> findRecentAll(int limit);
+
+    List<Long> findRecentByGenre(String genre, int limit);
+
+    default List<Long> findRecentIds(String genre, int limit) {
+        if (StringUtils.hasText(genre)) {
+            return findRecentByGenre(genre.trim().toLowerCase(), limit);
+        }
+        return findRecentAll(limit);
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.prography.lighton.performance.users.infrastructure.repository;
+
+import com.prography.lighton.genre.domain.entity.QGenre;
+import com.prography.lighton.performance.common.domain.entity.QPerformance;
+import com.prography.lighton.performance.common.domain.entity.association.QPerformanceGenre;
+import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class RecentPerformanceRepositoryImpl implements RecentPerformanceRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Long> findRecentAll(int limit) {
+        QPerformance p = QPerformance.performance;
+
+        return query
+                .select(p.id)
+                .from(p)
+                .where(
+                        p.approveStatus.eq(ApproveStatus.APPROVED),
+                        p.status.isTrue(),
+                        p.canceled.isFalse()
+                )
+                .orderBy(p.createdAt.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findRecentByGenre(String genre, int limit) {
+        QPerformance p = QPerformance.performance;
+        QPerformanceGenre pg = QPerformanceGenre.performanceGenre;
+        QGenre g = QGenre.genre;
+
+        return query
+                .select(p.id)
+                .distinct()
+                .from(p)
+                .join(p.genres, pg)
+                .join(pg.genre, g)
+                .where(
+                        p.approveStatus.eq(ApproveStatus.APPROVED),
+                        p.status.isTrue(),
+                        p.canceled.isFalse(),
+                        g.name.eq(genre)
+                )
+                .orderBy(p.createdAt.desc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
@@ -5,6 +5,7 @@ import com.prography.lighton.common.utils.ApiUtils;
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.performance.users.application.service.UserPopularService;
+import com.prography.lighton.performance.users.application.service.UserRecentPerformanceService;
 import com.prography.lighton.performance.users.application.service.UserRecommendationService;
 import com.prography.lighton.performance.users.presentation.dto.response.GetPerformanceBrowseResponse;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class UserPerformanceBrowseController {
 
     private final UserRecommendationService recommendationService;
     private final UserPopularService popularService;
+    private final UserRecentPerformanceService recentPerformanceService;
 
     @GetMapping("/recommend")
     public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getRecommendations(
@@ -33,6 +35,13 @@ public class UserPerformanceBrowseController {
     public ResponseEntity<ApiUtils.ApiResult<GetPerformanceBrowseResponse>> getPopulars(
             @RequestParam(required = false) String genre) {
         GetPerformanceBrowseResponse dto = popularService.getPopular(genre);
+        return ResponseEntity.ok(ApiUtils.success(dto));
+    }
+
+    @GetMapping("/recent")
+    public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getRecent(
+            @RequestParam(required = false) String genre) {
+        GetPerformanceBrowseResponse dto = recentPerformanceService.getRecentPerformances(genre);
         return ResponseEntity.ok(ApiUtils.success(dto));
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
 - #85 

## 🔧 작업 내용
- 로그인 하지 않은 회원들을 위한 최신 공연 조회 API 구현
- 공연 상세 조회 API 화이트 리스트 추가

## 💬 기타 사항
- 추천 및 인기 공연 로직을 최대한 활용 하는 방향으로 구현
- 지금 `PerformanceSummaryRepositoryImpl` 관련 하여 현재 공연 1개당 장르별로 중복된 DTO가 생성되는 문제를 발견 했습니다.
- 이 부분은 별도로 이슈 생성해서 해결하는게 나을 것 같아서 먼저 해당 기능 PR부터 작성 했습니다.

- 해당 문제는 `canceled = false` 조건을 추가 하면서 해결 됐습니다...! 자세한 내용은 모르겠지만요...ㅋㅋㅋㅋ

```json
      {
        "id": 25,
        "title": "얘가 뜨면 안되는데",
        "description": "테스트 아티스트의 콘서트입니다22222",
        "thumbnailImageUrl": "https://example.com",
        "genres": [
          "팝"
        ],
        "startDate": "2025-07-01",
        "startTime": "19:00:00",
        "isPaid": true,
        "regionName": "중구"
      },
      {
        "id": 25,
        "title": "얘가 뜨면 안되는데",
        "description": "테스트 아티스트의 콘서트입니다22222",
        "thumbnailImageUrl": "https://example.com",
        "genres": [
          "얼터너티브"
        ],
        "startDate": "2025-07-01",
        "startTime": "19:00:00",
        "isPaid": true,
        "regionName": "중구"
      },
```  

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public endpoint to browse recent performances, with optional filtering by genre.
  * Users can now view up to 30 of the most recent performances, accessible without authentication.
  * Expanded public access to recent and specific performance-related endpoints without authentication.

* **Bug Fixes**
  * Updated performance queries to exclude canceled performances from popular, recommended, and summary lists.

* **Chores**
  * Removed an unused method related to deleting performances by performer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->