### PR TITLE
[Feature] 최근 뜨는 아티스트 공연 조회

### DIFF
--- a/src/main/java/com/prography/lighton/artist/users/application/dto/ArtistRankDto.java
+++ b/src/main/java/com/prography/lighton/artist/users/application/dto/ArtistRankDto.java
@@ -1,0 +1,4 @@
+package com.prography.lighton.artist.users.application.dto;
+
+public record ArtistRankDto(Long artistId, Long likeCount) {
+}

--- a/src/main/java/com/prography/lighton/artist/users/application/service/ArtistLikeRedisService.java
+++ b/src/main/java/com/prography/lighton/artist/users/application/service/ArtistLikeRedisService.java
@@ -1,5 +1,6 @@
 package com.prography.lighton.artist.users.application.service;
 
+import com.prography.lighton.artist.users.application.dto.ArtistRankDto;
 import com.prography.lighton.common.infrastructure.redis.RedisZsetRepository;
 import java.time.Duration;
 import java.time.LocalDate;
@@ -59,8 +60,5 @@ public class ArtistLikeRedisService {
 
     private String buildKey(LocalDate date) {
         return "artist:likes:z:" + date.format(DTF);
-    }
-
-    public record ArtistRankDto(Long artistId, Long likeCount) {
     }
 }

--- a/src/main/java/com/prography/lighton/artist/users/application/service/ArtistLikeRedisService.java
+++ b/src/main/java/com/prography/lighton/artist/users/application/service/ArtistLikeRedisService.java
@@ -1,4 +1,4 @@
-package com.prography.lighton.performance.users.application.service;
+package com.prography.lighton.artist.users.application.service;
 
 import com.prography.lighton.common.infrastructure.redis.RedisZsetRepository;
 import java.time.Duration;

--- a/src/main/java/com/prography/lighton/artist/users/application/service/ArtistLikeRedisService.java
+++ b/src/main/java/com/prography/lighton/artist/users/application/service/ArtistLikeRedisService.java
@@ -21,9 +21,18 @@ public class ArtistLikeRedisService {
 
     private final RedisZsetRepository redisZsetRepository;
 
-    public void incrementToday(Long artistId) {
+    public void incrementToday(List<Long> artistIds) {
         String todayKey = buildKey(LocalDate.now());
-        redisZsetRepository.incrementScore(todayKey, artistId.toString(), 1, ZSET_TTL);
+        artistIds.stream()
+                .map(Object::toString)
+                .forEach(idStr ->
+                        redisZsetRepository.incrementScore(
+                                todayKey,
+                                idStr,
+                                1,
+                                ZSET_TTL
+                        )
+                );
     }
 
     public List<ArtistRankDto> topArtistsLast14Days(int topN) {

--- a/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
+++ b/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
@@ -46,6 +46,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/popular").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/nearby").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/recent").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances/hot-artist").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/*").permitAll()
 

--- a/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
+++ b/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
@@ -16,6 +16,7 @@ public final class SecurityWhitelist {
             "/api/members/performances/nearby",
             "/api/members/performances/popular",
             "/api/members/performances/recent",
+            "/api/members/performances/hot-artist"
     };
 
     // 접두사로 매칭되는 경로들

--- a/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisRepository.java
@@ -1,6 +1,8 @@
 package com.prography.lighton.common.infrastructure.redis;
 
 import java.time.Duration;
+import java.util.Collection;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -31,4 +33,7 @@ public class RedisRepository {
         return value;
     }
 
+    public List<String> multiGet(Collection<String> keys) {
+        return redisTemplate.opsForValue().multiGet(keys);
+    }
 }

--- a/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisRepository.java
@@ -22,4 +22,13 @@ public class RedisRepository {
     public void delete(String key) {
         redisTemplate.delete(key);
     }
+
+    public Long increment(String key, long delta, Duration ttl) {
+        Long value = redisTemplate.opsForValue().increment(key, delta);
+        if (redisTemplate.getExpire(key) == -1) {
+            redisTemplate.expire(key, ttl);
+        }
+        return value;
+    }
+
 }

--- a/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisRepository.java
+++ b/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisRepository.java
@@ -2,14 +2,14 @@ package com.prography.lighton.common.infrastructure.redis;
 
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class RedisRepository {
 
-    private final RedisTemplate<String, String> redisTemplate;
+    private final StringRedisTemplate redisTemplate;
 
     public void save(String key, String value, Duration ttl) {
         redisTemplate.opsForValue().set(key, value, ttl);

--- a/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisZsetRepository.java
+++ b/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisZsetRepository.java
@@ -1,0 +1,20 @@
+package com.prography.lighton.common.infrastructure.redis;
+
+import java.time.Duration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RedisZsetRepository {
+
+    private final StringRedisTemplate redisTemplate;
+
+    public Double incrementScore(String key, String member, double delta, Duration ttl) {
+        Double score = redisTemplate.opsForZSet().incrementScore(key, member, delta);
+        redisTemplate.expire(key, ttl);
+        return score;
+    }
+
+}

--- a/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisZsetRepository.java
+++ b/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisZsetRepository.java
@@ -1,6 +1,7 @@
 package com.prography.lighton.common.infrastructure.redis;
 
 import java.time.Duration;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Component;
@@ -15,6 +16,16 @@ public class RedisZsetRepository {
         Double score = redisTemplate.opsForZSet().incrementScore(key, member, delta);
         redisTemplate.expire(key, ttl);
         return score;
+    }
+
+    public void unionAndStore(String destKey, List<String> sourceKeys, Duration ttl) {
+        if (sourceKeys.isEmpty()) {
+            return;
+        }
+        String first = sourceKeys.getFirst();
+        redisTemplate.opsForZSet()
+                .unionAndStore(first, sourceKeys.subList(1, sourceKeys.size()), destKey);
+        redisTemplate.expire(destKey, ttl);
     }
 
 }

--- a/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisZsetRepository.java
+++ b/src/main/java/com/prography/lighton/common/infrastructure/redis/RedisZsetRepository.java
@@ -2,8 +2,10 @@ package com.prography.lighton.common.infrastructure.redis;
 
 import java.time.Duration;
 import java.util.List;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations.TypedTuple;
 import org.springframework.stereotype.Component;
 
 @Component
@@ -28,4 +30,7 @@ public class RedisZsetRepository {
         redisTemplate.expire(destKey, ttl);
     }
 
+    public Set<TypedTuple<String>> reverseRangeWithScores(String key, long start, long end) {
+        return redisTemplate.opsForZSet().reverseRangeWithScores(key, start, end);
+    }
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/ArtistLikeRedisService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/ArtistLikeRedisService.java
@@ -1,0 +1,26 @@
+package com.prography.lighton.performance.users.application.service;
+
+import com.prography.lighton.common.infrastructure.redis.RedisRepository;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArtistLikeRedisService {
+
+    private static final Duration TTL_14_DAYS = Duration.ofDays(14);
+    private final RedisRepository redis;
+
+    public void incrementToday(Long artistId) {
+        String key = buildKey(artistId, LocalDate.now());
+        redis.increment(key, 1, TTL_14_DAYS);
+    }
+
+    private String buildKey(Long artistId, LocalDate date) {
+        return "artist:likes:%d:%s".formatted(
+                artistId, date.format(DateTimeFormatter.BASIC_ISO_DATE));
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
@@ -4,9 +4,11 @@ import com.prography.lighton.artist.users.application.service.ArtistLikeRedisSer
 import com.prography.lighton.artist.users.application.service.ArtistLikeRedisService.ArtistRankDto;
 import com.prography.lighton.performance.users.application.resolver.PerformanceListHelper;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceLatestByArtistRepository;
+import com.prography.lighton.performance.users.infrastructure.repository.RecentPerformanceRepository;
 import com.prography.lighton.performance.users.presentation.dto.response.GetPerformanceBrowseResponse;
-import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,43 +19,55 @@ import org.springframework.transaction.annotation.Transactional;
 public class UserHotArtistPerformanceService {
 
     private static final String LATEST_HOT_CACHE_KEY_PREFIX = "latest_hot";
+    private static final int TOP_ARTIST_COUNT = 10;
+    private static final int HOT_PERFORMANCE_COUNT = 5;
 
     private final PerformanceLatestByArtistRepository latestRepository;
     private final ArtistLikeRedisService artistLikeRedisService;
     private final PerformanceListHelper helper;
-    private final UserRecentPerformanceService recentPerformanceService;
+    private final RecentPerformanceRepository recentRepository;
 
     public GetPerformanceBrowseResponse getLatestHotArtistPerformance() {
         String key = LATEST_HOT_CACHE_KEY_PREFIX;
         GetPerformanceBrowseResponse response = helper.fetchWithCache(
                 key,
                 () -> findLatestHotPerformanceIds());
-        if (response.performances().isEmpty()) {
-            response = recentPerformanceService.getRecentPerformances("");
-        }
         return response;
     }
 
     private List<Long> findLatestHotPerformanceIds() {
+        List<Long> topArtists = artistLikeRedisService
+                .topArtistsLast14Days(TOP_ARTIST_COUNT)
+                .stream()
+                .map(ArtistRankDto::artistId)
+                .toList();
 
-        List<Long> popularArtistIds = artistLikeRedisService.topArtistsLast14Days(30)
-                .stream().map(ArtistRankDto::artistId).toList();
-
-        if (popularArtistIds.isEmpty()) {
-            return List.of();
-        }
-
-        List<Long> ids = latestRepository.findLatestUpcomingIdsByArtists(
-                popularArtistIds, LocalDate.now());
-
-        // 아티스트 인기 순서를 유지하며 5개 선택해야함, 지금은 해당 로직 없음.
-        //List<Long> ordered = ids.subList(0, 5);
-
-        if (ids.size() < 5) {
-
-        }
-
-        return ids;
+        return buildHotPerformances(topArtists);
     }
+
+    private List<Long> buildHotPerformances(List<Long> artistIds) {
+        if (artistIds.isEmpty()) {
+            return recentRepository.findRecentAll(HOT_PERFORMANCE_COUNT);
+        }
+
+        List<Long> hotIds = artistIds.stream()
+                .map(latestRepository::findLatestUpcomingIdByArtist)
+                .flatMap(Optional::stream)
+                .distinct()
+                .limit(HOT_PERFORMANCE_COUNT)
+                .toList();
+
+        if (hotIds.size() < HOT_PERFORMANCE_COUNT) {
+            int needed = HOT_PERFORMANCE_COUNT - hotIds.size();
+            List<Long> fallback = recentRepository
+                    .findRecentExcluding(hotIds, needed);
+            hotIds = Stream.concat(hotIds.stream(), fallback.stream())
+                    .limit(HOT_PERFORMANCE_COUNT)
+                    .toList();
+        }
+
+        return hotIds;
+    }
+
 
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
@@ -1,7 +1,7 @@
 package com.prography.lighton.performance.users.application.service;
 
+import com.prography.lighton.artist.users.application.dto.ArtistRankDto;
 import com.prography.lighton.artist.users.application.service.ArtistLikeRedisService;
-import com.prography.lighton.artist.users.application.service.ArtistLikeRedisService.ArtistRankDto;
 import com.prography.lighton.performance.users.application.resolver.PerformanceListHelper;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceLatestByArtistRepository;
 import com.prography.lighton.performance.users.infrastructure.repository.RecentPerformanceRepository;

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
@@ -1,0 +1,51 @@
+package com.prography.lighton.performance.users.application.service;
+
+import com.prography.lighton.artist.users.application.service.ArtistLikeRedisService;
+import com.prography.lighton.artist.users.application.service.ArtistLikeRedisService.ArtistRankDto;
+import com.prography.lighton.performance.users.application.resolver.PerformanceListHelper;
+import com.prography.lighton.performance.users.infrastructure.repository.PerformanceLatestByArtistRepository;
+import com.prography.lighton.performance.users.presentation.dto.response.GetPerformanceBrowseResponse;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class UserHotArtistPerformanceService {
+
+    private static final String LATEST_HOT_CACHE_KEY_PREFIX = "latest_hot";
+
+    private final PerformanceLatestByArtistRepository latestRepository;
+    private final ArtistLikeRedisService artistLikeRedisService;
+    private final PerformanceListHelper helper;
+
+    public GetPerformanceBrowseResponse getLatestHotArtistPerformance() {
+        String key = LATEST_HOT_CACHE_KEY_PREFIX;
+        return helper.fetchWithCache(
+                key,
+                () -> findLatestHotPerformanceIds());
+    }
+
+    private List<Long> findLatestHotPerformanceIds() {
+
+        List<Long> popularArtistIds = artistLikeRedisService.topArtistsLast14Days(30)
+                .stream().map(ArtistRankDto::artistId).toList();
+
+        if (popularArtistIds.isEmpty()) {
+            return List.of();
+        }
+
+        List<Long> ids = latestRepository.findLatestUpcomingIdsByArtists(
+                popularArtistIds, LocalDate.now());
+
+        // 아티스트 인기 순서를 유지하며 5개 선택해야함, 지금은 해당 로직 없음.
+        List<Long> ordered = ids.subList(0, 5);
+
+        return ordered;
+    }
+
+
+}

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
@@ -21,12 +21,17 @@ public class UserHotArtistPerformanceService {
     private final PerformanceLatestByArtistRepository latestRepository;
     private final ArtistLikeRedisService artistLikeRedisService;
     private final PerformanceListHelper helper;
+    private final UserRecentPerformanceService recentPerformanceService;
 
     public GetPerformanceBrowseResponse getLatestHotArtistPerformance() {
         String key = LATEST_HOT_CACHE_KEY_PREFIX;
-        return helper.fetchWithCache(
+        GetPerformanceBrowseResponse response = helper.fetchWithCache(
                 key,
                 () -> findLatestHotPerformanceIds());
+        if (response.performances().isEmpty()) {
+            response = recentPerformanceService.getRecentPerformances("");
+        }
+        return response;
     }
 
     private List<Long> findLatestHotPerformanceIds() {
@@ -42,10 +47,13 @@ public class UserHotArtistPerformanceService {
                 popularArtistIds, LocalDate.now());
 
         // 아티스트 인기 순서를 유지하며 5개 선택해야함, 지금은 해당 로직 없음.
-        List<Long> ordered = ids.subList(0, 5);
+        //List<Long> ordered = ids.subList(0, 5);
 
-        return ordered;
+        if (ids.size() < 5) {
+
+        }
+
+        return ids;
     }
-
 
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserHotArtistPerformanceService.java
@@ -29,10 +29,8 @@ public class UserHotArtistPerformanceService {
 
     public GetPerformanceBrowseResponse getLatestHotArtistPerformance() {
         String key = LATEST_HOT_CACHE_KEY_PREFIX;
-        GetPerformanceBrowseResponse response = helper.fetchWithCache(
-                key,
-                () -> findLatestHotPerformanceIds());
-        return response;
+        return helper.fetchWithCache(
+                key, this::findLatestHotPerformanceIds);
     }
 
     private List<Long> findLatestHotPerformanceIds() {
@@ -68,6 +66,4 @@ public class UserHotArtistPerformanceService {
 
         return hotIds;
     }
-
-
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceLikeService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceLikeService.java
@@ -1,11 +1,13 @@
 package com.prography.lighton.performance.users.application.service;
 
+import com.prography.lighton.artist.users.application.service.ArtistLikeRedisService;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.performance.common.domain.entity.Performance;
 import com.prography.lighton.performance.common.domain.entity.PerformanceLike;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceLikeRepository;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceRepository;
 import com.prography.lighton.performance.users.presentation.dto.response.LikePerformanceResponse;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +19,7 @@ public class UserPerformanceLikeService {
 
     private final PerformanceRepository performanceRepository;
     private final PerformanceLikeRepository performanceLikeRepository;
+    private final ArtistLikeRedisService likeRedisService;
 
     @Transactional
     public LikePerformanceResponse likeOrUnlikePerformance(Member member, Long performanceId) {
@@ -26,6 +29,13 @@ public class UserPerformanceLikeService {
                 .orElseGet(() -> PerformanceLike.of(member, performance, false));
 
         boolean nowLiked = like.toggleLike();
+        if (nowLiked) {
+            List<Long> artistIds = performance.getArtists().stream()
+                    .map(pa -> pa.getArtist().getId())
+                    .toList();
+
+            likeRedisService.incrementToday(artistIds);
+        }
         performanceLikeRepository.save(like);
         return LikePerformanceResponse.of(nowLiked);
     }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceLikeService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceLikeService.java
@@ -4,6 +4,7 @@ import com.prography.lighton.artist.users.application.service.ArtistLikeRedisSer
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.performance.common.domain.entity.Performance;
 import com.prography.lighton.performance.common.domain.entity.PerformanceLike;
+import com.prography.lighton.performance.common.domain.entity.enums.Type;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceLikeRepository;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceRepository;
 import com.prography.lighton.performance.users.presentation.dto.response.LikePerformanceResponse;
@@ -29,7 +30,7 @@ public class UserPerformanceLikeService {
                 .orElseGet(() -> PerformanceLike.of(member, performance, false));
 
         boolean nowLiked = like.toggleLike();
-        if (nowLiked) {
+        if (nowLiked && performance.getType() == Type.CONCERT) {
             List<Long> artistIds = performance.getArtists().stream()
                     .map(pa -> pa.getArtist().getId())
                     .toList();

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepository.java
@@ -1,8 +1,8 @@
 package com.prography.lighton.performance.users.infrastructure.repository;
 
-import java.util.List;
+import java.util.Optional;
 
 public interface PerformanceLatestByArtistRepository {
 
-    List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds);
+    Optional<Long> findLatestUpcomingIdByArtist(long artistId);
 }

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepository.java
@@ -1,9 +1,8 @@
 package com.prography.lighton.performance.users.infrastructure.repository;
 
-import java.time.LocalDate;
 import java.util.List;
 
 public interface PerformanceLatestByArtistRepository {
 
-    List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds, LocalDate today);
+    List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds);
 }

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepository.java
@@ -1,0 +1,9 @@
+package com.prography.lighton.performance.users.infrastructure.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface PerformanceLatestByArtistRepository {
+
+    List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds, LocalDate today);
+}

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
@@ -41,6 +41,7 @@ public class PerformanceLatestByArtistRepositoryImpl implements PerformanceLates
 
         return query
                 .select(performance.id)
+                .distinct()
                 .from(performance)
                 .join(performance.artists, performanceArtist)
                 .where(

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
@@ -21,10 +21,11 @@ public class PerformanceLatestByArtistRepositoryImpl implements PerformanceLates
     private final JPAQueryFactory query;
 
     @Override
-    public List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds, LocalDate today) {
+    public List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds) {
 
         QPerformance pSub = new QPerformance("pSub");
         QPerformanceArtist paSub = new QPerformanceArtist("paSub");
+        LocalDate today = LocalDate.now();
 
         var latestPerArtist = JPAExpressions
                 .select(pSub.id.max())

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
@@ -1,0 +1,51 @@
+package com.prography.lighton.performance.users.infrastructure.repository;
+
+
+import static com.prography.lighton.performance.common.domain.entity.QPerformance.performance;
+import static com.prography.lighton.performance.common.domain.entity.association.QPerformanceArtist.performanceArtist;
+
+import com.prography.lighton.performance.common.domain.entity.QPerformance;
+import com.prography.lighton.performance.common.domain.entity.association.QPerformanceArtist;
+import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class PerformanceLatestByArtistRepositoryImpl implements PerformanceLatestByArtistRepository {
+
+    private final JPAQueryFactory query;
+
+    @Override
+    public List<Long> findLatestUpcomingIdsByArtists(List<Long> artistIds, LocalDate today) {
+
+        QPerformance pSub = new QPerformance("pSub");
+        QPerformanceArtist paSub = new QPerformanceArtist("paSub");
+
+        var latestPerArtist = JPAExpressions
+                .select(pSub.id.max())
+                .from(pSub)
+                .join(pSub.artists, paSub)
+                .where(
+                        paSub.artist.id.in(artistIds),
+                        pSub.canceled.isFalse(),
+                        pSub.approveStatus.eq(ApproveStatus.APPROVED),
+                        pSub.schedule.endDate.goe(today)
+                )
+                .groupBy(paSub.artist.id);
+
+        return query
+                .select(performance.id)
+                .from(performance)
+                .join(performance.artists, performanceArtist)
+                .where(
+                        performanceArtist.artist.id.in(artistIds),
+                        performance.id.in(latestPerArtist)
+                )
+                .fetch();
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
@@ -32,6 +32,7 @@ public class PerformanceLatestByArtistRepositoryImpl implements PerformanceLates
                 .join(pSub.artists, paSub)
                 .where(
                         paSub.artist.id.in(artistIds),
+                        pSub.status.isTrue(),
                         pSub.canceled.isFalse(),
                         pSub.approveStatus.eq(ApproveStatus.APPROVED),
                         pSub.schedule.endDate.goe(today)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceLatestByArtistRepositoryImpl.java
@@ -3,6 +3,7 @@ package com.prography.lighton.performance.users.infrastructure.repository;
 import com.prography.lighton.performance.common.domain.entity.QPerformance;
 import com.prography.lighton.performance.common.domain.entity.association.QPerformanceArtist;
 import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
+import com.prography.lighton.performance.common.domain.entity.enums.Type;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.Optional;
@@ -30,7 +31,8 @@ public class PerformanceLatestByArtistRepositoryImpl implements PerformanceLates
                         p.status.isTrue(),
                         p.canceled.isFalse(),
                         p.approveStatus.eq(ApproveStatus.APPROVED),
-                        p.schedule.endDate.goe(today)
+                        p.schedule.endDate.goe(today),
+                        p.type.eq(Type.CONCERT)
                 )
                 .fetchOne();
 

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRecommendationRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRecommendationRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.prography.lighton.member.common.domain.entity.association.QPreferredG
 import com.prography.lighton.performance.common.domain.entity.QPerformance;
 import com.prography.lighton.performance.common.domain.entity.association.QPerformanceGenre;
 import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
+import com.prography.lighton.performance.common.domain.entity.enums.Type;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
@@ -34,7 +35,8 @@ public class PerformanceRecommendationRepositoryImpl implements PerformanceRecom
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.schedule.endDate.goe(LocalDate.now()),
                         p.status.eq(true),
-                        p.canceled.isFalse()
+                        p.canceled.isFalse(),
+                        p.type.eq(Type.CONCERT)
                 )
                 .groupBy(p.id)
                 .orderBy(

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepository.java
@@ -1,6 +1,5 @@
 package com.prography.lighton.performance.users.infrastructure.repository;
 
-import java.time.LocalDate;
 import java.util.List;
 import org.springframework.util.StringUtils;
 
@@ -10,7 +9,7 @@ public interface RecentPerformanceRepository {
 
     List<Long> findRecentByGenre(String genre, int limit);
 
-    List<Long> findRecentExcluding(List<Long> excludeIds, int limit, LocalDate today);
+    List<Long> findRecentExcluding(List<Long> excludeIds, int limit);
 
     default List<Long> findRecentIds(String genre, int limit) {
         if (StringUtils.hasText(genre)) {

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepository.java
@@ -1,5 +1,6 @@
 package com.prography.lighton.performance.users.infrastructure.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import org.springframework.util.StringUtils;
 
@@ -8,6 +9,8 @@ public interface RecentPerformanceRepository {
     List<Long> findRecentAll(int limit);
 
     List<Long> findRecentByGenre(String genre, int limit);
+
+    List<Long> findRecentExcluding(List<Long> excludeIds, int limit, LocalDate today);
 
     default List<Long> findRecentIds(String genre, int limit) {
         if (StringUtils.hasText(genre)) {

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.prography.lighton.performance.common.domain.entity.QPerformance;
 import com.prography.lighton.performance.common.domain.entity.association.QPerformanceGenre;
 import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -49,6 +50,25 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
                         p.status.isTrue(),
                         p.canceled.isFalse(),
                         g.name.eq(genre)
+                )
+                .orderBy(p.createdAt.desc())
+                .limit(limit)
+                .fetch();
+    }
+
+    @Override
+    public List<Long> findRecentExcluding(List<Long> excludeIds, int limit, LocalDate today) {
+        QPerformance p = QPerformance.performance;
+
+        return query
+                .select(p.id)
+                .from(p)
+                .where(
+                        p.id.notIn(excludeIds),
+                        p.approveStatus.eq(ApproveStatus.APPROVED),
+                        p.status.isTrue(),
+                        p.canceled.isFalse(),
+                        p.schedule.endDate.goe(today)
                 )
                 .orderBy(p.createdAt.desc())
                 .limit(limit)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
@@ -19,6 +19,7 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
     @Override
     public List<Long> findRecentAll(int limit) {
         QPerformance p = QPerformance.performance;
+        LocalDate today = LocalDate.now();
 
         return query
                 .select(p.id)
@@ -26,7 +27,8 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
                 .where(
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.status.isTrue(),
-                        p.canceled.isFalse()
+                        p.canceled.isFalse(),
+                        p.schedule.endDate.goe(today)
                 )
                 .orderBy(p.createdAt.desc())
                 .limit(limit)
@@ -38,6 +40,7 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
         QPerformance p = QPerformance.performance;
         QPerformanceGenre pg = QPerformanceGenre.performanceGenre;
         QGenre g = QGenre.genre;
+        LocalDate today = LocalDate.now();
 
         return query
                 .select(p.id)
@@ -49,7 +52,8 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.status.isTrue(),
                         p.canceled.isFalse(),
-                        g.name.eq(genre)
+                        g.name.eq(genre),
+                        p.schedule.endDate.goe(today)
                 )
                 .orderBy(p.createdAt.desc())
                 .limit(limit)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
@@ -57,8 +57,9 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
     }
 
     @Override
-    public List<Long> findRecentExcluding(List<Long> excludeIds, int limit, LocalDate today) {
+    public List<Long> findRecentExcluding(List<Long> excludeIds, int limit) {
         QPerformance p = QPerformance.performance;
+        LocalDate today = LocalDate.now();
 
         return query
                 .select(p.id)

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/RecentPerformanceRepositoryImpl.java
@@ -4,6 +4,7 @@ import com.prography.lighton.genre.domain.entity.QGenre;
 import com.prography.lighton.performance.common.domain.entity.QPerformance;
 import com.prography.lighton.performance.common.domain.entity.association.QPerformanceGenre;
 import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
+import com.prography.lighton.performance.common.domain.entity.enums.Type;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDate;
 import java.util.List;
@@ -28,7 +29,8 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.status.isTrue(),
                         p.canceled.isFalse(),
-                        p.schedule.endDate.goe(today)
+                        p.schedule.endDate.goe(today),
+                        p.type.eq(Type.CONCERT)
                 )
                 .orderBy(p.createdAt.desc())
                 .limit(limit)
@@ -53,7 +55,8 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
                         p.status.isTrue(),
                         p.canceled.isFalse(),
                         g.name.eq(genre),
-                        p.schedule.endDate.goe(today)
+                        p.schedule.endDate.goe(today),
+                        p.type.eq(Type.CONCERT)
                 )
                 .orderBy(p.createdAt.desc())
                 .limit(limit)
@@ -73,7 +76,8 @@ public class RecentPerformanceRepositoryImpl implements RecentPerformanceReposit
                         p.approveStatus.eq(ApproveStatus.APPROVED),
                         p.status.isTrue(),
                         p.canceled.isFalse(),
-                        p.schedule.endDate.goe(today)
+                        p.schedule.endDate.goe(today),
+                        p.type.eq(Type.CONCERT)
                 )
                 .orderBy(p.createdAt.desc())
                 .limit(limit)

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
@@ -4,6 +4,7 @@ import com.prography.lighton.common.annotation.LoginMember;
 import com.prography.lighton.common.utils.ApiUtils;
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
 import com.prography.lighton.member.common.domain.entity.Member;
+import com.prography.lighton.performance.users.application.service.UserHotArtistPerformanceService;
 import com.prography.lighton.performance.users.application.service.UserPopularService;
 import com.prography.lighton.performance.users.application.service.UserRecentPerformanceService;
 import com.prography.lighton.performance.users.application.service.UserRecommendationService;
@@ -23,6 +24,7 @@ public class UserPerformanceBrowseController {
     private final UserRecommendationService recommendationService;
     private final UserPopularService popularService;
     private final UserRecentPerformanceService recentPerformanceService;
+    private final UserHotArtistPerformanceService hotArtistPerformanceService;
 
     @GetMapping("/recommend")
     public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getRecommendations(
@@ -44,4 +46,11 @@ public class UserPerformanceBrowseController {
         GetPerformanceBrowseResponse dto = recentPerformanceService.getRecentPerformances(genre);
         return ResponseEntity.ok(ApiUtils.success(dto));
     }
+
+    @GetMapping("/hot-artist")
+    public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getRecommendations() {
+        GetPerformanceBrowseResponse dto = hotArtistPerformanceService.getLatestHotArtistPerformance();
+        return ResponseEntity.ok(ApiUtils.success(dto));
+    }
+
 }

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
@@ -47,7 +47,7 @@ public class UserPerformanceBrowseController {
         return ResponseEntity.ok(ApiUtils.success(dto));
     }
 
-    @GetMapping("/hot-artist")
+    @GetMapping("/trending")
     public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getRecommendations() {
         GetPerformanceBrowseResponse dto = hotArtistPerformanceService.getLatestHotArtistPerformance();
         return ResponseEntity.ok(ApiUtils.success(dto));

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceBrowseController.java
@@ -48,7 +48,7 @@ public class UserPerformanceBrowseController {
     }
 
     @GetMapping("/trending")
-    public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getRecommendations() {
+    public ResponseEntity<ApiResult<GetPerformanceBrowseResponse>> getLatestHotArtistPerformance() {
         GetPerformanceBrowseResponse dto = hotArtistPerformanceService.getLatestHotArtistPerformance();
         return ResponseEntity.ok(ApiUtils.success(dto));
     }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #91 
## 🔧 작업 내용
최근 뜨는 아티스트 공연 조회 기능 구현


<아티스트 좋아요>
- 레디스에 아티스트 별 하루 좋아요 개수 저장(ttl 14일)
- 공연 좋아요 누르면 그 날의 아티스트 좋아요 개수+1


<최근 뜨는 아티스트 공연 조회>
: 공연 개수는 항상 5개로 반환
- 레디스에서 오늘 기준으로 14일 전까지의 아티스트 별 좋아요 개수 합산
- 좋아요 개수를 기준으로 상위 10명 조회
- 각 아티스트의 최신 공연 조회
- 10명의 아티스트의 최신 공연이 5개가 되지 않을 때, 나머지는 최신 공연으로 채움


## 💬 기타 사항 
- 최신 공연 조회 시 공연 마감일이 오늘 이후인지 확인하는 조건 추가
- 최신 공연 조회 시 "콘서트" 타입 조건 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new public API endpoint to browse hot artist performances.
  * Hot artist performances are now curated based on artist like counts from recent user activity.
  * Unauthenticated users can access the hot artist performances endpoint.

* **Enhancements**
  * Liking a concert performance now increases the associated artist's popularity in real time.
  * Improved backend performance for retrieving and ranking hot artists and their latest performances.
  * Recommendations and recent performance listings now exclusively show upcoming approved concerts.

* **Bug Fixes**
  * Recent performances now consistently filter for concerts that are upcoming and approved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->