### PR TITLE
[Feature] 사용자 - 공연 결제 정보 조회 API 구현 

### DIFF
--- a/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
+++ b/src/main/java/com/prography/lighton/common/config/SecurityConfig.java
@@ -48,7 +48,7 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/recent").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances/trending").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/performances").permitAll()
-                        .requestMatchers(HttpMethod.GET, "/api/members/performances/*").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/api/members/performances/**").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/advertisements").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/announcements").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/members/announcements/*").permitAll()

--- a/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
+++ b/src/main/java/com/prography/lighton/common/constant/SecurityWhitelist.java
@@ -34,7 +34,8 @@ public final class SecurityWhitelist {
     // 정규식으로 매칭되는 경로들
     public static final String[] REGEX_MATCH = {
             "^/api/members/\\d+/info$",
-            "^/api/members/performances/\\d+$"
+            "^/api/members/performances/\\d+",
+            "^/api/members/performances/\\d+/payment$"
     };
 
     private SecurityWhitelist() {

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
@@ -18,6 +18,7 @@ import com.prography.lighton.performance.common.domain.entity.vo.Info;
 import com.prography.lighton.performance.common.domain.entity.vo.Location;
 import com.prography.lighton.performance.common.domain.entity.vo.Payment;
 import com.prography.lighton.performance.common.domain.entity.vo.Schedule;
+import com.prography.lighton.performance.common.domain.exception.FreePerformanceException;
 import com.prography.lighton.performance.common.domain.exception.InvalidSeatCountException;
 import com.prography.lighton.performance.common.domain.exception.MasterArtistCannotBeRemovedException;
 import com.prography.lighton.performance.common.domain.exception.NotAuthorizedPerformanceException;
@@ -304,6 +305,12 @@ public class Performance extends BaseEntity {
         }
     }
 
+    public void validateExistPaymentDetails() {
+        if (!this.payment.getIsPaid()) {
+            throw new FreePerformanceException();
+        }
+    }
+
     public void cancel(Member member) {
         validatePerformer(member);
         validateWithinAllowedPeriod(CANCEL_DEADLINE_DAYS);
@@ -379,7 +386,7 @@ public class Performance extends BaseEntity {
         validateRequest(applySeats);
 
         this.bookedSeatCount += applySeats;
-        return PerformanceRequest.of(member, this, applySeats, payment.getFee() * applySeats);
+        return PerformanceRequest.of(member, this, applySeats, payment.getFee());
     }
 
     public void cancelRequest(int requestedSeats) {
@@ -390,11 +397,8 @@ public class Performance extends BaseEntity {
     }
 
     private void validateRequest(Integer applySeats) {
+        System.out.println(applySeats);
         if (applySeats == null || applySeats < MIN_REQUESTED_SEATS || applySeats > MAX_REQUESTED_SEATS) {
-            throw new BadPerformanceRequestException();
-        }
-
-        if (this.type.equals(Type.CONCERT)) {
             throw new BadPerformanceRequestException();
         }
 

--- a/src/main/java/com/prography/lighton/performance/common/domain/exception/FreePerformanceException.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/exception/FreePerformanceException.java
@@ -1,0 +1,16 @@
+package com.prography.lighton.performance.common.domain.exception;
+
+import com.prography.lighton.common.exception.base.InvalidException;
+
+public class FreePerformanceException extends InvalidException {
+
+    private static final String MESSAGE = "해당 공연은 무료 공연입니다. 결제 정보가 존재하지 않습니다.";
+
+    public FreePerformanceException() {
+        super(MESSAGE);
+    }
+
+    public FreePerformanceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
@@ -11,7 +11,7 @@ import com.prography.lighton.performance.users.infrastructure.repository.Perform
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyPerformanceStatsResponseDTO;
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyRegisteredPerformanceListResponseDTO;
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyRequestedPerformanceListResponseDTO;
-import com.prography.lighton.performance.users.presentation.dto.response.RequestPerformanceResponseDTO;
+import com.prography.lighton.performance.users.presentation.dto.response.GetPerformancePaymentInfoResponse;
 import com.prography.lighton.region.domain.entity.SubRegion;
 import com.prography.lighton.region.infrastructure.cache.RegionCache;
 import java.time.LocalDate;
@@ -39,9 +39,16 @@ public class UserPerformanceService {
         return performanceDetailMapper.toDetailDTO(performance);
     }
 
+    public GetPerformancePaymentInfoResponse getPerformancePaymentDetail(Long performanceId, Integer applySeats) {
+        Performance performance = performanceRepository.getById(performanceId);
+        performance.validateExistPaymentDetails();
+
+        return GetPerformancePaymentInfoResponse.of(performance, applySeats);
+    }
+
     @Transactional
-    public RequestPerformanceResponseDTO requestForPerformance(Long performanceId, Integer applySeats,
-                                                               Member member) {
+    public GetPerformancePaymentInfoResponse requestForPerformance(Long performanceId, Integer applySeats,
+                                                                   Member member) {
         Performance performance = performanceRepository.getByIdWithPessimisticLock(performanceId);
         performance.validateApproved();
 
@@ -52,7 +59,7 @@ public class UserPerformanceService {
         PerformanceRequest performanceRequest = performance.createRequest(applySeats, member);
         performanceRequestRepository.save(performanceRequest);
 
-        return RequestPerformanceResponseDTO.of(performance, applySeats);
+        return GetPerformancePaymentInfoResponse.of(performance, applySeats);
     }
 
     @Transactional

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceController.java
@@ -10,6 +10,8 @@ import com.prography.lighton.performance.users.presentation.dto.response.GetMyPe
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyRegisteredPerformanceListResponseDTO;
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyRequestedPerformanceListResponseDTO;
 import com.prography.lighton.performance.users.presentation.dto.response.GetPerformancePaymentInfoResponse;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -35,7 +37,7 @@ public class UserPerformanceController {
     @GetMapping("/{performanceId}/payment")
     public ResponseEntity<ApiResult<GetPerformancePaymentInfoResponse>> getPerformancePayment(
             @PathVariable Long performanceId,
-            @RequestParam Integer applySeats
+            @RequestParam @Min(1) @Max(10) Integer applySeats
     ) {
         return ResponseEntity.ok(
                 ApiUtils.success(userPerformanceService.getPerformancePaymentDetail(performanceId, applySeats)));
@@ -44,7 +46,7 @@ public class UserPerformanceController {
     @PostMapping("/{performanceId}/request")
     public ResponseEntity<ApiResult<GetPerformancePaymentInfoResponse>> requestForPerformance(
             @PathVariable Long performanceId,
-            @RequestParam Integer applySeats,
+            @RequestParam @Min(1) @Max(10) Integer applySeats,
             @LoginMember Member member) {
         return ResponseEntity.ok(ApiUtils.success(userPerformanceService.requestForPerformance(
                 performanceId, applySeats, member

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceController.java
@@ -9,7 +9,7 @@ import com.prography.lighton.performance.users.application.service.UserPerforman
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyPerformanceStatsResponseDTO;
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyRegisteredPerformanceListResponseDTO;
 import com.prography.lighton.performance.users.presentation.dto.response.GetMyRequestedPerformanceListResponseDTO;
-import com.prography.lighton.performance.users.presentation.dto.response.RequestPerformanceResponseDTO;
+import com.prography.lighton.performance.users.presentation.dto.response.GetPerformancePaymentInfoResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -32,8 +32,17 @@ public class UserPerformanceController {
         return ResponseEntity.ok(ApiUtils.success(userPerformanceService.getPerformanceDetail(performanceId)));
     }
 
+    @GetMapping("/{performanceId}/payment")
+    public ResponseEntity<ApiResult<GetPerformancePaymentInfoResponse>> getPerformancePayment(
+            @PathVariable Long performanceId,
+            @RequestParam Integer applySeats
+    ) {
+        return ResponseEntity.ok(
+                ApiUtils.success(userPerformanceService.getPerformancePaymentDetail(performanceId, applySeats)));
+    }
+
     @PostMapping("/{performanceId}")
-    public ResponseEntity<ApiResult<RequestPerformanceResponseDTO>> requestForPerformance(
+    public ResponseEntity<ApiResult<GetPerformancePaymentInfoResponse>> requestForPerformance(
             @PathVariable Long performanceId,
             @RequestParam Integer applySeats,
             @LoginMember Member member) {

--- a/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceController.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/controller/UserPerformanceController.java
@@ -41,7 +41,7 @@ public class UserPerformanceController {
                 ApiUtils.success(userPerformanceService.getPerformancePaymentDetail(performanceId, applySeats)));
     }
 
-    @PostMapping("/{performanceId}")
+    @PostMapping("/{performanceId}/request")
     public ResponseEntity<ApiResult<GetPerformancePaymentInfoResponse>> requestForPerformance(
             @PathVariable Long performanceId,
             @RequestParam Integer applySeats,

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/GetPerformancePaymentInfoResponse.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/GetPerformancePaymentInfoResponse.java
@@ -2,14 +2,14 @@ package com.prography.lighton.performance.users.presentation.dto.response;
 
 import com.prography.lighton.performance.common.domain.entity.Performance;
 
-public record RequestPerformanceResponseDTO(
+public record GetPerformancePaymentInfoResponse(
         String account,
         String bank,
         String accountHolder,
         Integer fee
 ) {
-    public static RequestPerformanceResponseDTO of(Performance performance, Integer requestedSeats) {
-        return new RequestPerformanceResponseDTO(
+    public static GetPerformancePaymentInfoResponse of(Performance performance, Integer requestedSeats) {
+        return new GetPerformancePaymentInfoResponse(
                 performance.getPayment().getAccount(),
                 performance.getPayment().getBank(),
                 performance.getPayment().getAccountHolder(),
@@ -17,3 +17,4 @@ public record RequestPerformanceResponseDTO(
         );
     }
 }
+

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/GetPerformancePaymentInfoResponse.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/GetPerformancePaymentInfoResponse.java
@@ -13,8 +13,15 @@ public record GetPerformancePaymentInfoResponse(
                 performance.getPayment().getAccount(),
                 performance.getPayment().getBank(),
                 performance.getPayment().getAccountHolder(),
-                performance.getPayment().getFee() * requestedSeats
+                getTotalFee(performance, requestedSeats)
         );
+    }
+
+    public static int getTotalFee(Performance performance, Integer requestedSeats) {
+        if (!performance.getPayment().getIsPaid()) {
+            return 0;
+        }
+        return performance.getPayment().getFee() * requestedSeats;
     }
 }
 


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #105 

## 🔧 작업 내용
- 공연 결제 정보 조회 API 구현 

## 💬 기타 사항
- 해당 API 화이트 리스트 추가 및 명세서 작성 완료
- 현재 JWT 필터링 오류로 공연 신청 API에서 403 에러가 반복적으로 발생 
    - 공연 신청 API 엔드포인트 수정 및 화이트 리스트 수정으로 인해 해결
