### PR TITLE
[Feature] 버스킹 등록 요청 DTO 내 불필요한 버스킹 증빙자료 URL 필드 삭제

### DIFF
--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/ArtistBuskingUpdateRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/ArtistBuskingUpdateRequest.java
@@ -2,7 +2,6 @@ package com.prography.lighton.performance.users.presentation.dto.request;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.URL;
 
 public record ArtistBuskingUpdateRequest(
 
@@ -12,9 +11,7 @@ public record ArtistBuskingUpdateRequest(
 
         @NotNull(message = "공연 일정 정보는 필수입니다.")
         @Valid
-        ScheduleDTO schedule,
+        ScheduleDTO schedule
 
-        @URL(message = "공연 증빙 자료는 올바른 URL 형식이어야 합니다.")
-        String proof
 ) {
 }

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/PerformanceUpdateRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/PerformanceUpdateRequest.java
@@ -5,7 +5,6 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
-import org.hibernate.validator.constraints.URL;
 
 public record PerformanceUpdateRequest(
 
@@ -24,10 +23,7 @@ public record PerformanceUpdateRequest(
         PaymentDTO payment,
 
         @NotEmpty(message = "좌석 유형은 하나 이상 선택해야 합니다.")
-        List<@NotNull(message = "좌석 유형은 비어 있을 수 없습니다.") Seat> seat,
-
-        @URL(message = "공연 증빙 자료는 올바른 URL 형식이어야 합니다.")
-        String proof
+        List<@NotNull(message = "좌석 유형은 비어 있을 수 없습니다.") Seat> seat
 
 ) {
 }

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/SaveUserBuskingRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/SaveUserBuskingRequest.java
@@ -3,7 +3,6 @@ package com.prography.lighton.performance.users.presentation.dto.request;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import org.hibernate.validator.constraints.URL;
 
 public record SaveUserBuskingRequest(
 
@@ -14,10 +13,6 @@ public record SaveUserBuskingRequest(
         @NotNull(message = "공연 일정 정보는 필수입니다.")
         @Valid
         ScheduleDTO schedule,
-
-        @NotBlank(message = "공연 증빙 자료 URL은 필수입니다.")
-        @URL(message = "공연 증빙 자료는 올바른 URL 형식이어야 합니다.")
-        String proof,
 
         @NotBlank(message = "아티스트 이름은 필수입니다.")
         String artistName,


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #108 
## 🔧 작업 내용
- 버스킹 등록 API 요청 내 불필요한 필드 삭제
## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the "proof" field from various user and performance update forms. Users are no longer required to provide a proof URL when updating or saving busking or performance information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->