### PR TITLE
[Bug] 일반 사용자 공연 조회 누락 문제 해결

### DIFF
--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
@@ -110,11 +110,13 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 
     @Query("""
                 SELECT DISTINCT p
-                FROM Performance p
-                LEFT JOIN PerformanceArtist pa ON pa.performance = p
-                WHERE (p.performer = :member OR pa.artist.member = :member)
-                  AND p.status = true
-                ORDER BY p.createdAt DESC
+                                               FROM Performance p
+                                               LEFT JOIN p.artists pa
+                                               LEFT JOIN pa.artist a
+                                                    WITH a.status = true
+                                              WHERE p.status = true
+                                                AND (p.performer = :member OR a.member = :member)
+                                           ORDER BY p.createdAt DESC
             """)
     List<Performance> getMyRegisteredOrParticipatedPerformanceList(@Param("member") Member member);
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #111 
## 🔧 작업 내용
‘내 등록 공연 조회’ 시 일반 사용자(공연 등록자)의 공연이 조회되지 않는 문제가 발생.
공연에 아티스트 정보가 연결되지 않은 경우에도 조회되도록 쿼리를 수정함.

## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the logic for retrieving your registered or participated performances, enhancing filtering and accuracy of the displayed results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->