### PR TITLE
[Feature] 내가 신청한 공연의 아티스트 조회 API 구현

### DIFF
--- a/src/main/java/com/prography/lighton/member/users/application/UserMemberQueryService.java
+++ b/src/main/java/com/prography/lighton/member/users/application/UserMemberQueryService.java
@@ -1,12 +1,16 @@
 package com.prography.lighton.member.users.application;
 
+import com.prography.lighton.artist.common.domain.entity.Artist;
 import com.prography.lighton.genre.domain.entity.Genre;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.member.common.domain.entity.association.PreferredGenre;
 import com.prography.lighton.member.common.infrastructure.repository.MemberRepository;
 import com.prography.lighton.member.common.infrastructure.repository.PreferredGenreRepository;
 import com.prography.lighton.member.users.presentation.dto.response.CheckDuplicateEmailResponse;
+import com.prography.lighton.member.users.presentation.dto.response.GetMyPreferredArtistsResponse;
 import com.prography.lighton.member.users.presentation.dto.response.GetPreferredGenreResponse;
+import com.prography.lighton.performance.users.application.service.ArtistPerformanceService;
+import com.prography.lighton.performance.users.application.service.UserPerformanceService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,6 +24,9 @@ public class UserMemberQueryService {
     private final MemberRepository memberRepository;
     private final PreferredGenreRepository preferredGenreRepository;
 
+    private final UserPerformanceService userPerformanceService;
+    private final ArtistPerformanceService artistPerformanceService;
+
     public CheckDuplicateEmailResponse checkEmailExists(String email) {
         return CheckDuplicateEmailResponse.of(memberRepository.existsByEmail(email));
     }
@@ -30,5 +37,17 @@ public class UserMemberQueryService {
                 .toList();
 
         return GetPreferredGenreResponse.of(genres);
+    }
+
+    public GetMyPreferredArtistsResponse getMyPreferredArtists(Member member) {
+        // 현재 구현은 내가 신청했던 공연의 아티스트 조회 - 추후 아티스트 페이지 개발 시 변경 예정
+        List<Long> appliedPerformanceIds = userPerformanceService.getAppliedPerformances(member);
+        if (appliedPerformanceIds.isEmpty()) {
+            return GetMyPreferredArtistsResponse.of(List.of());
+        }
+
+        List<Artist> preferredArtists = artistPerformanceService.getArtistsByAppliedPerformanceIds(
+                appliedPerformanceIds);
+        return GetMyPreferredArtistsResponse.of(preferredArtists);
     }
 }

--- a/src/main/java/com/prography/lighton/member/users/presentation/UserMemberController.java
+++ b/src/main/java/com/prography/lighton/member/users/presentation/UserMemberController.java
@@ -11,6 +11,7 @@ import com.prography.lighton.member.users.presentation.dto.request.EditMemberGen
 import com.prography.lighton.member.users.presentation.dto.request.RegisterMemberRequest;
 import com.prography.lighton.member.users.presentation.dto.response.CheckDuplicateEmailResponse;
 import com.prography.lighton.member.users.presentation.dto.response.CompleteMemberProfileResponse;
+import com.prography.lighton.member.users.presentation.dto.response.GetMyPreferredArtistsResponse;
 import com.prography.lighton.member.users.presentation.dto.response.GetPreferredGenreResponse;
 import com.prography.lighton.member.users.presentation.dto.response.RegisterMemberResponse;
 import jakarta.validation.Valid;
@@ -68,5 +69,13 @@ public class UserMemberController {
     public ResponseEntity<ApiResult<CheckDuplicateEmailResponse>> duplicateCheck(@RequestParam String email) {
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiUtils.success(userMemberQueryService.checkEmailExists(email)));
+    }
+
+    @GetMapping("/preferred-artist")
+    public ResponseEntity<ApiResult<GetMyPreferredArtistsResponse>> getMyPreferredArtists(
+            @LoginMember Member member) {
+        // 현재 구현은 내가 신청했던 공연의 아티스트 조회 - 추후 아티스트 페이지 개발 시 변경 예정
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiUtils.success(userMemberQueryService.getMyPreferredArtists(member)));
     }
 }

--- a/src/main/java/com/prography/lighton/member/users/presentation/dto/response/GetMyPreferredArtistsResponse.java
+++ b/src/main/java/com/prography/lighton/member/users/presentation/dto/response/GetMyPreferredArtistsResponse.java
@@ -1,0 +1,24 @@
+package com.prography.lighton.member.users.presentation.dto.response;
+
+import com.prography.lighton.artist.common.domain.entity.Artist;
+import java.util.List;
+
+public record GetMyPreferredArtistsResponse(List<ArtistResponse> artists) {
+
+    public static GetMyPreferredArtistsResponse of(List<Artist> artists) {
+        return new GetMyPreferredArtistsResponse(
+                artists.stream()
+                        .map(ArtistResponse::of)
+                        .toList());
+    }
+
+    private record ArtistResponse(
+            long id,
+            String name,
+            String profileImageUrl
+    ) {
+        public static ArtistResponse of(Artist artist) {
+            return new ArtistResponse(artist.getId(), artist.getStageName(), artist.getProfileImageUrl());
+        }
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/application/service/ArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/ArtistPerformanceService.java
@@ -1,12 +1,15 @@
 package com.prography.lighton.performance.users.application.service;
 
+import com.prography.lighton.artist.common.domain.entity.Artist;
 import com.prography.lighton.common.geo.BoundingBox;
 import com.prography.lighton.common.geo.GeoUtils;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.performance.common.domain.entity.Performance;
+import com.prography.lighton.performance.common.domain.entity.association.PerformanceArtist;
 import com.prography.lighton.performance.common.domain.entity.enums.PerformanceFilterType;
 import com.prography.lighton.performance.common.domain.entity.enums.Type;
 import com.prography.lighton.performance.users.application.resolver.PerformanceResolver;
+import com.prography.lighton.performance.users.infrastructure.repository.PerformanceArtistRepository;
 import com.prography.lighton.performance.users.infrastructure.repository.PerformanceRepository;
 import com.prography.lighton.performance.users.presentation.dto.request.RegisterPerformanceMultiPart;
 import com.prography.lighton.performance.users.presentation.dto.request.UpdatePerformanceMultiPart;
@@ -29,6 +32,7 @@ public class ArtistPerformanceService {
     private static final Integer CLOSING_SOON_DAYS = 1;
 
     private final PerformanceRepository performanceRepository;
+    private final PerformanceArtistRepository performanceArtistRepository;
     private final PerformanceResolver performanceResolver;
 
     public Performance getApprovedPerformanceById(Long id) {
@@ -84,6 +88,12 @@ public class ArtistPerformanceService {
 
         List<Performance> performances = findPerformancesByType(type, today, box);
         return GetPerformanceMapListResponseDTO.from(performances);
+    }
+
+    public List<Artist> getArtistsByAppliedPerformanceIds(List<Long> performanceIds) {
+        return performanceArtistRepository.findAllByPerformances(performanceIds).stream()
+                .map(PerformanceArtist::getArtist)
+                .toList();
     }
 
     private List<Performance> findPerformancesByType(PerformanceFilterType type, LocalDate today, BoundingBox box) {

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
@@ -107,4 +107,11 @@ public class UserPerformanceService {
                         + mostParticipatedSubRegion.getName()
         );
     }
+
+    public List<Long> getAppliedPerformances(Member member) {
+        return performanceRequestRepository.findAllByMember(member).stream()
+                .map(PerformanceRequest::getPerformance)
+                .map(Performance::getId)
+                .toList();
+    }
 }

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceArtistRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceArtistRepository.java
@@ -1,0 +1,19 @@
+package com.prography.lighton.performance.users.infrastructure.repository;
+
+import com.prography.lighton.performance.common.domain.entity.association.PerformanceArtist;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface PerformanceArtistRepository extends JpaRepository<PerformanceArtist, Long> {
+
+    @Query("""
+            SELECT pa FROM PerformanceArtist pa
+            JOIN FETCH pa.artist a
+            WHERE pa.performance.id IN :performanceIds
+              AND pa.status = true
+              AND a.status = true
+              AND a.approveStatus = 'APPROVED'
+            """)
+    List<PerformanceArtist> findAllByPerformances(List<Long> performanceIds);
+}

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRequestRepository.java
@@ -22,6 +22,15 @@ public interface PerformanceRequestRepository extends JpaRepository<PerformanceR
 
     Optional<PerformanceRequest> findByMemberAndPerformance(Member member, Performance performance);
 
+    @Query("""
+                SELECT pr FROM PerformanceRequest pr
+                JOIN FETCH pr.performance p
+                WHERE pr.member = :member
+                  AND pr.performance.status = true
+                  AND pr.performance.approveStatus = 'APPROVED'
+                  AND pr.requestStatus IN ('PENDING', 'APPROVED')
+                ORDER BY pr.createdAt DESC
+            """)
     List<PerformanceRequest> findAllByMember(Member member);
 
     @Modifying


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #118 

## 🔧 작업 내용
- 현재 마이페이지에 필요한 "내가 좋아하는 아티스트 조회" 기능을 구현해야 하지만, 아직 아티스트 좋아요 기능이 없는 상황
- 이를 대체한 "내가 신청한 공연의 아티스트 조회" 기능을 구현함
## 💬 기타 사항
