### PR TITLE
[Feature] 마이페이지 조회 API에 이름 필드 추가

### DIFF
--- a/src/main/java/com/prography/lighton/member/users/application/UserMemberQueryService.java
+++ b/src/main/java/com/prography/lighton/member/users/application/UserMemberQueryService.java
@@ -7,6 +7,7 @@ import com.prography.lighton.member.common.domain.entity.association.PreferredGe
 import com.prography.lighton.member.common.infrastructure.repository.MemberRepository;
 import com.prography.lighton.member.common.infrastructure.repository.PreferredGenreRepository;
 import com.prography.lighton.member.users.presentation.dto.response.CheckDuplicateEmailResponse;
+import com.prography.lighton.member.users.presentation.dto.response.GetMemberInfoResponse;
 import com.prography.lighton.member.users.presentation.dto.response.GetMyPreferredArtistsResponse;
 import com.prography.lighton.member.users.presentation.dto.response.GetPreferredGenreResponse;
 import com.prography.lighton.performance.users.application.service.ArtistPerformanceService;
@@ -49,5 +50,9 @@ public class UserMemberQueryService {
         List<Artist> preferredArtists = artistPerformanceService.getArtistsByAppliedPerformanceIds(
                 appliedPerformanceIds);
         return GetMyPreferredArtistsResponse.of(preferredArtists);
+    }
+
+    public GetMemberInfoResponse getMyInfo(Member member) {
+        return GetMemberInfoResponse.of(member);
     }
 }

--- a/src/main/java/com/prography/lighton/member/users/presentation/UserMemberController.java
+++ b/src/main/java/com/prography/lighton/member/users/presentation/UserMemberController.java
@@ -11,6 +11,7 @@ import com.prography.lighton.member.users.presentation.dto.request.EditMemberGen
 import com.prography.lighton.member.users.presentation.dto.request.RegisterMemberRequest;
 import com.prography.lighton.member.users.presentation.dto.response.CheckDuplicateEmailResponse;
 import com.prography.lighton.member.users.presentation.dto.response.CompleteMemberProfileResponse;
+import com.prography.lighton.member.users.presentation.dto.response.GetMemberInfoResponse;
 import com.prography.lighton.member.users.presentation.dto.response.GetMyPreferredArtistsResponse;
 import com.prography.lighton.member.users.presentation.dto.response.GetPreferredGenreResponse;
 import com.prography.lighton.member.users.presentation.dto.response.RegisterMemberResponse;
@@ -77,5 +78,11 @@ public class UserMemberController {
         // 현재 구현은 내가 신청했던 공연의 아티스트 조회 - 추후 아티스트 페이지 개발 시 변경 예정
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiUtils.success(userMemberQueryService.getMyPreferredArtists(member)));
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<ApiResult<GetMemberInfoResponse>> getMyInfo(@LoginMember Member member) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiUtils.success(userMemberQueryService.getMyInfo(member)));
     }
 }

--- a/src/main/java/com/prography/lighton/member/users/presentation/dto/response/GetMemberInfoResponse.java
+++ b/src/main/java/com/prography/lighton/member/users/presentation/dto/response/GetMemberInfoResponse.java
@@ -1,0 +1,13 @@
+package com.prography.lighton.member.users.presentation.dto.response;
+
+import com.prography.lighton.member.common.domain.entity.Member;
+
+public record GetMemberInfoResponse(
+        long id,
+        String name
+) {
+    public static GetMemberInfoResponse of(Member member) {
+        return new GetMemberInfoResponse(member.getId(), member.getName());
+
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserPerformanceService.java
@@ -101,13 +101,14 @@ public class UserPerformanceService {
                 LocalTime.now());
 
         if (mostParticipatedSubRegionCode == null) {
-            return GetMyPerformanceStatsResponseDTO.of(applyCount, null);
+            return GetMyPerformanceStatsResponseDTO.of(member.getName(), applyCount, null);
         }
 
         SubRegion mostParticipatedSubRegion = regionCache.getRegionInfoByCode(mostParticipatedSubRegionCode)
                 .getSubRegion();
 
         return GetMyPerformanceStatsResponseDTO.of(
+                member.getName(),
                 applyCount,
                 mostParticipatedSubRegion.getRegion().getName()
                         + BLANK

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/GetMyPerformanceStatsResponseDTO.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/GetMyPerformanceStatsResponseDTO.java
@@ -1,10 +1,12 @@
 package com.prography.lighton.performance.users.presentation.dto.response;
 
 public record GetMyPerformanceStatsResponseDTO(
+        String name,
         Integer totalPerformances,
         String mostPreferredRegion
 ) {
-    public static GetMyPerformanceStatsResponseDTO of(Integer totalPerformances, String mostPreferredRegion) {
-        return new GetMyPerformanceStatsResponseDTO(totalPerformances, mostPreferredRegion);
+    public static GetMyPerformanceStatsResponseDTO of(String name, Integer totalPerformances,
+                                                      String mostPreferredRegion) {
+        return new GetMyPerformanceStatsResponseDTO(name, totalPerformances, mostPreferredRegion);
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #123 

## 🔧 작업 내용
- 마이페이지 조회 API에 이름 필드 추가
## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * User performance statistics responses now include the user's name alongside their performance data.
  * Added a new endpoint to retrieve authenticated user information, including user ID and name.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->