### PR TITLE
[Feature] 선호 장르 수정 시, 관련 캐시 초기화

### DIFF
--- a/src/main/java/com/prography/lighton/member/users/application/UserMemberCommandService.java
+++ b/src/main/java/com/prography/lighton/member/users/application/UserMemberCommandService.java
@@ -21,6 +21,7 @@ import com.prography.lighton.member.users.presentation.dto.request.EditMemberGen
 import com.prography.lighton.member.users.presentation.dto.request.RegisterMemberRequest;
 import com.prography.lighton.member.users.presentation.dto.response.CompleteMemberProfileResponse;
 import com.prography.lighton.member.users.presentation.dto.response.RegisterMemberResponse;
+import com.prography.lighton.performance.users.application.service.UserRecommendationService;
 import com.prography.lighton.region.infrastructure.cache.RegionCache;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -42,6 +43,7 @@ public class UserMemberCommandService {
     private final RegionCache regionCache;
     private final TokenProvider tokenProvider;
     private final AuthVerificationService authVerificationService;
+    private final UserRecommendationService userRecommendationService;
 
     public CompleteMemberProfileResponse completeMemberProfile(final Long temporaryMemberId,
                                                                final CompleteMemberProfileRequest request) {
@@ -131,5 +133,6 @@ public class UserMemberCommandService {
 
     private void deletePreviousPreferredGenres(Member member) {
         preferredGenreRepository.deleteAllByMember(member);
+        userRecommendationService.deleteCache(member);
     }
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/resolver/PerformanceListHelper.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/resolver/PerformanceListHelper.java
@@ -44,5 +44,9 @@ public class PerformanceListHelper {
 
         return GetPerformanceBrowseResponse.of(summaries);
     }
+
+    public void deleteCache(String cacheKey) {
+        cache.delete(cacheKey);
+    }
 }
 

--- a/src/main/java/com/prography/lighton/performance/users/application/service/PerformanceRedisService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/PerformanceRedisService.java
@@ -40,4 +40,8 @@ public class PerformanceRedisService {
                 .map(String::valueOf).toList());
         redisRepository.save(key, csv, ttlToday());
     }
+
+    public void delete(String key) {
+        redisRepository.delete(key);
+    }
 }

--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserRecommendationService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserRecommendationService.java
@@ -26,6 +26,11 @@ public class UserRecommendationService {
                 () -> recommendationRepository.findTopRecommendedIds(member.getId(), LIMIT));
     }
 
+    public void deleteCache(Member member) {
+        String key = buildKey(member);
+        helper.deleteCache(key);
+    }
+
     private String buildKey(Member member) {
         return RECOMMENDATION_CACHE_KEY_PREFIX + member.getId();
     }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #126 

## 🔧 작업 내용
- 현재 선호 장르 수정 후 추천 공연 조회 시, 수정한 장르에 맞게 공연이 추천되지 않음
    - 캐시가 함께 비워지지 않아 이전 선호 장르 기반 캐시 데이터에 맞게 조회 됨
- 이를 방지하기 위해 선호 장르 수정 시, 관련 캐시 지우도록 기능 추가

## 💬 기타 사항
