### PR TITLE
[Bug] 선호 장르가 없을 때 추천 공연 조회 불가 문제 해결

### DIFF
--- a/src/main/java/com/prography/lighton/performance/users/application/service/UserRecommendationService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/UserRecommendationService.java
@@ -18,8 +18,12 @@ public class UserRecommendationService {
 
     private final PerformanceListHelper helper;
     private final PerformanceRecommendationRepository recommendationRepository;
+    private final UserRecentPerformanceService recentPerformanceService;
 
     public GetPerformanceBrowseResponse getRecommendations(Member member) {
+        if (member.getPreferredGenres().isEmpty()) {
+            return recentPerformanceService.getRecentPerformances(null);
+        }
         String key = buildKey(member);
         return helper.fetchWithCache(
                 key,


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #134 
## 🔧 작업 내용
선호 장르가 비어있을 땐 최신 공연 데이터 반환
## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Recommendations now gracefully fallback to recent performances when a user has no preferred genres, ensuring immediate, relevant content for first-time users or users without set preferences.
  * Existing personalized recommendations remain unchanged for users with preferences, preserving tailored suggestions.
  * Delivers a more consistent and engaging experience across different user states by avoiding empty or less relevant recommendation screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->