### PR TITLE
[Feature] 공연 승인 상태에 '취소' 항목 추가 

### DIFF
--- a/src/main/java/com/prography/lighton/performance/common/application/mapper/PerformanceDetailMapper.java
+++ b/src/main/java/com/prography/lighton/performance/common/application/mapper/PerformanceDetailMapper.java
@@ -64,6 +64,7 @@ public class PerformanceDetailMapper {
                 .proofUrl(p.getProofUrl())
                 .isPaid(p.getPayment().getIsPaid())
                 .fee(p.getPayment().getFee())
+                .status(p.getApproveStatus())
                 .build();
     }
 
@@ -90,6 +91,7 @@ public class PerformanceDetailMapper {
                 .proofUrl(b.getProofUrl())
                 .isPaid(b.getPayment().getIsPaid())
                 .fee(b.getPayment().getFee())
+                .status(b.getApproveStatus())
                 .build();
     }
 

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
@@ -216,6 +216,7 @@ public class Performance extends BaseEntity {
         if (this.canceled) {
             throw new IllegalStateException("이미 취소된 공연입니다.");
         }
+        managePerformanceApplication(ApproveStatus.CANCELED);
         this.canceled = true;
     }
 

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/enums/ApproveStatus.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/enums/ApproveStatus.java
@@ -3,7 +3,7 @@ package com.prography.lighton.performance.common.domain.entity.enums;
 import com.prography.lighton.artist.admin.domain.exception.UnsupportedApproveStatusTypeException;
 
 public enum ApproveStatus {
-    PENDING, APPROVED, REJECTED;
+    PENDING, APPROVED, REJECTED, CANCELED;
 
     public static ApproveStatus from(String value) {
         try {

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/policy/ApprovalPolicy.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/policy/ApprovalPolicy.java
@@ -21,9 +21,10 @@ public final class ApprovalPolicy {
 
     private static boolean isAllowed(ApproveStatus from, ApproveStatus to) {
         return switch (from) {
-            case PENDING -> (to == ApproveStatus.APPROVED || to == ApproveStatus.REJECTED);
-            case APPROVED -> (to == ApproveStatus.PENDING);
-            case REJECTED -> false;
+            case PENDING ->
+                    (to == ApproveStatus.APPROVED || to == ApproveStatus.REJECTED || to == ApproveStatus.CANCELED);
+            case APPROVED -> (to == ApproveStatus.PENDING || to == ApproveStatus.CANCELED);
+            case CANCELED, REJECTED -> false;
         };
     }
 

--- a/src/main/java/com/prography/lighton/performance/common/presentation/dto/response/GetPerformanceDetailResponseDTO.java
+++ b/src/main/java/com/prography/lighton/performance/common/presentation/dto/response/GetPerformanceDetailResponseDTO.java
@@ -1,5 +1,6 @@
 package com.prography.lighton.performance.common.presentation.dto.response;
 
+import com.prography.lighton.performance.common.domain.entity.enums.ApproveStatus;
 import com.prography.lighton.performance.common.domain.entity.enums.Seat;
 import com.prography.lighton.performance.common.domain.entity.enums.Type;
 import com.prography.lighton.performance.common.domain.entity.vo.Info;
@@ -20,7 +21,8 @@ public record GetPerformanceDetailResponseDTO(
         List<Seat> seats,
         String proofUrl,
         Boolean isPaid,
-        Integer fee
+        Integer fee,
+        ApproveStatus status
 ) {
     public record ArtistDTO(Long id, String name, String description) {
         public static ArtistDTO of(Long id, String name, String description) {

--- a/src/main/java/com/prography/lighton/performance/users/application/service/BuskingService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/BuskingService.java
@@ -23,12 +23,6 @@ public class BuskingService {
     private final PerformanceResolver performanceResolver;
     private final ArtistService artistService;
 
-    public Busking getApprovedBuskingById(Long id) {
-        Busking performance = performanceRepository.getByBuskingId(id);
-        performance.validateApproved();
-        return performance;
-    }
-
     @Transactional
     public void registerBuskingByUser(Member member, RegisterUserBuskingMultiPart request) {
         var data = performanceResolver.toNewBuskingData(member, request.data().info(), request.data().schedule(),
@@ -53,7 +47,7 @@ public class BuskingService {
 
     @Transactional
     public void updateBuskingByUser(Member member, Long buskingId, UpdateUserBuskingMultiPart request) {
-        Busking busking = getApprovedBuskingById(buskingId);
+        Busking busking = performanceRepository.getByBuskingId(buskingId);
         var data = performanceResolver.toUpdateBuskingData(member, busking, request.data().info(),
                 request.data().schedule(),
                 request.posterImage(),
@@ -64,7 +58,7 @@ public class BuskingService {
 
     @Transactional
     public void updateBuskingByArtist(Member member, Long buskingId, UpdateArtistBuskingMultiPart request) {
-        Busking busking = getApprovedBuskingById(buskingId);
+        Busking busking = performanceRepository.getByBuskingId(buskingId);
         var data = performanceResolver.toUpdateBuskingData(member, busking, request.data().info(),
                 request.data().schedule(),
                 request.posterImage(), request.proof());
@@ -73,7 +67,7 @@ public class BuskingService {
 
     @Transactional
     public void cancelBusking(Member member, Long buskingId) {
-        Busking busking = getApprovedBuskingById(buskingId);
+        Busking busking = performanceRepository.getByBuskingId(buskingId);
         busking.cancel(member);
     }
 }

--- a/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
+++ b/src/main/java/com/prography/lighton/performance/users/infrastructure/repository/PerformanceRepository.java
@@ -48,6 +48,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
                 JOIN FETCH p.genres pg
                 WHERE p.location.latitude BETWEEN :minLat AND :maxLat
                   AND p.location.longitude BETWEEN :minLng AND :maxLng
+                AND p.canceled = false
                   AND p.status = true
             """)
     List<Performance> findRoughlyWithinBox(double minLat, double maxLat, double minLng, double maxLng);
@@ -57,6 +58,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
                 JOIN performance_genre pg ON p.id = pg.performance_id
                 WHERE p.latitude BETWEEN :minLat AND :maxLat
                 AND p.longitude BETWEEN :minLng AND :maxLng
+                AND p.canceled = false
                 AND p.status = true
                 ORDER BY RAND()
                 LIMIT 3
@@ -71,6 +73,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
                 WHERE p.approvedAt >= :fromDate
                   AND p.location.latitude BETWEEN :minLat AND :maxLat
                   AND p.location.longitude BETWEEN :minLng AND :maxLng
+                AND p.canceled = false
                   AND p.status = true
             """)
     List<Performance> findRegisteredInLastWeekWithinBox(double minLat, double maxLat,
@@ -89,6 +92,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
                 )
                 AND p.location.latitude BETWEEN :minLat AND :maxLat
                 AND p.location.longitude BETWEEN :minLng AND :maxLng
+                AND p.canceled = false
                 AND p.status = true
             """)
     List<Performance> findClosingSoonWithinBox(
@@ -116,6 +120,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
                                                     WITH a.status = true
                                               WHERE p.status = true
                                                 AND (p.performer = :member OR a.member = :member)
+                                                AND p.canceled = false
                                            ORDER BY p.createdAt DESC
             """)
     List<Performance> getMyRegisteredOrParticipatedPerformanceList(@Param("member") Member member);

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/enums/PerformanceStatus.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/enums/PerformanceStatus.java
@@ -26,6 +26,8 @@ public enum PerformanceStatus {
             return PerformanceStatus.APPROVED;
         } else if (approveStatus == ApproveStatus.REJECTED) {
             return PerformanceStatus.REJECTED;
+        } else if (approveStatus == ApproveStatus.CANCELED) {
+            return PerformanceStatus.CANCELED;
         }
 
         throw new UnsupportedTypeException("지원하지 않는 공연 상태입니다.");

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/enums/PerformanceStatus.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/response/enums/PerformanceStatus.java
@@ -7,11 +7,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public enum PerformanceStatus {
-    PENDING, APPROVED, FINISHED, REJECTED;
+    PENDING, APPROVED, FINISHED, REJECTED, CANCELED;
 
     public static PerformanceStatus getPerformanceStatus(
             ApproveStatus approveStatus, LocalDate finishDate, LocalTime finishTime) {
-        
+
         LocalDateTime currentDateTime = LocalDateTime.now();
 
         if (currentDateTime.toLocalDate().isAfter(finishDate) ||


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #153 
## 🔧 작업 내용
- 공연 승인 상태에 '취소' 항목 추가 
- 사용자/관리자 공연 상세 조회 응답에 공연 상태값 필드 추가
## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * Performance details now display an explicit status, including a new CANCELED state.
  * Status mapping is unified across concert and busking details and user-facing performance status.

* Bug Fixes
  * Canceled performances are excluded from recommendations, nearby searches, recent listings, closing-soon, and personal performance lists.
  * Cancellation now consistently updates the performance’s approval state, ensuring accurate status and timestamps across the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->