### PR TITLE
[Feature] 공연 신청 API 내부 로직 변경

### DIFF
--- a/src/main/java/com/prography/lighton/performance/artist/application/ArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/artist/application/ArtistPerformanceService.java
@@ -8,5 +8,5 @@ public interface ArtistPerformanceService {
 
     GetPerformanceRequestsResponseDTO getPerformanceRequests(Long performanceId, Member member);
 
-    void managePerformanceRequest(Long performanceId, Member member, RequestStatus requestStatus);
+    void managePerformanceRequest(Long performanceId, Long applicantId, Member member, RequestStatus requestStatus);
 }

--- a/src/main/java/com/prography/lighton/performance/artist/application/impl/ArtistPerformanceServiceImpl.java
+++ b/src/main/java/com/prography/lighton/performance/artist/application/impl/ArtistPerformanceServiceImpl.java
@@ -3,6 +3,7 @@ package com.prography.lighton.performance.artist.application.impl;
 import com.prography.lighton.genre.domain.entity.Genre;
 import com.prography.lighton.genre.infrastructure.cache.GenreCache;
 import com.prography.lighton.member.common.domain.entity.Member;
+import com.prography.lighton.member.common.infrastructure.repository.MemberRepository;
 import com.prography.lighton.performance.artist.application.ArtistPerformanceService;
 import com.prography.lighton.performance.artist.presentation.dto.response.GetPerformanceRequestsResponseDTO;
 import com.prography.lighton.performance.common.domain.entity.Performance;
@@ -23,6 +24,7 @@ public class ArtistPerformanceServiceImpl implements ArtistPerformanceService {
 
     private final GenreCache genreCache;
 
+    private final MemberRepository memberRepository;
     private final PerformanceRepository performanceRepository;
     private final PerformanceRequestRepository performanceRequestRepository;
 
@@ -41,11 +43,14 @@ public class ArtistPerformanceServiceImpl implements ArtistPerformanceService {
 
     @Override
     @Transactional
-    public void managePerformanceRequest(Long performanceId, Member member, RequestStatus requestStatus) {
+    public void managePerformanceRequest(Long performanceId, Long applicantId, Member member,
+                                         RequestStatus requestStatus) {
         Performance performance = performanceRepository.getById(performanceId);
         performance.validateIsManagedBy(member);
 
-        PerformanceRequest performanceRequest = performanceRequestRepository.getByMemberAndPerformance(member, performance);
+        Member applicant = memberRepository.getMemberById(applicantId);
+        PerformanceRequest performanceRequest = performanceRequestRepository.getByMemberAndPerformance(applicant,
+                performance);
         performanceRequest.updateRequestStatus(requestStatus);
 
         // TODO 확정 시 유저에게 알림 발송

--- a/src/main/java/com/prography/lighton/performance/artist/presentation/ArtistPerformanceController.java
+++ b/src/main/java/com/prography/lighton/performance/artist/presentation/ArtistPerformanceController.java
@@ -32,13 +32,14 @@ public class ArtistPerformanceController {
                 ApiUtils.success(artistPerformanceService.getPerformanceRequests(performanceId, member)));
     }
 
-    @PostMapping("/{performanceId}/requests")
+    @PostMapping("/{performanceId}/applicants/{applicantId}/requests")
     public ResponseEntity<ApiResult<?>> managePerformanceRequest(
             @PathVariable Long performanceId,
+            @PathVariable Long applicantId,
             @LoginMember Member member,
             @RequestParam RequestStatus requestStatus
     ) {
-        artistPerformanceService.managePerformanceRequest(performanceId, member, requestStatus);
+        artistPerformanceService.managePerformanceRequest(performanceId, applicantId, member, requestStatus);
         return ResponseEntity.ok(ApiUtils.success());
     }
 }


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
- #156 

## 🔧 작업 내용
- 해당 공연의 신청자의 식별자를 입력 받아와 처리하도록 로직 수정 
    -  이전에는 로그인 한 회원의 공연 신청을 처리하는 상태

## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Breaking Changes
  - The API endpoint for managing performance requests now requires an applicantId in the path: changed from /{performanceId}/requests to /{performanceId}/applicants/{applicantId}/requests.
  - Requests must include the applicantId parameter alongside performanceId and requestStatus.
  - Update any client integrations to use the new route and parameter to avoid failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->