### PR TITLE
[Feature] 같은 이메일로 임시 회원 여러개 만들 수 있도록 로직 변경

### DIFF
--- a/src/main/java/com/prography/lighton/auth/application/service/LoginMemberService.java
+++ b/src/main/java/com/prography/lighton/auth/application/service/LoginMemberService.java
@@ -38,7 +38,7 @@ public class LoginMemberService {
     }
 
     private void validateIsNotTemporaryMember(String email) {
-        if (temporaryMemberRepository.existsByEmailAndNotRegistered(email)) {
+        if (temporaryMemberRepository.existsByEmailAndSocialLoginTypeAndNotRegistered(email, SocialLoginType.DEFAULT)) {
             throw new InvalidMemberException("개인 정보를 입력해주세요.");
         }
     }

--- a/src/main/java/com/prography/lighton/auth/application/service/OAuthService.java
+++ b/src/main/java/com/prography/lighton/auth/application/service/OAuthService.java
@@ -87,7 +87,8 @@ public class OAuthService {
             return issueTokensFor(member);
         }
 
-        TemporaryMember tempMember = temporaryMemberRepository.findByEmailAndNotRegistered(emailVO.getValue())
+        TemporaryMember tempMember = temporaryMemberRepository.findByEmailAndSocialLoginTypeAndNotRegistered(
+                        emailVO.getValue(), socialLoginType)
                 .orElseGet(() -> temporaryMemberRepository.save(
                         TemporaryMember.socialLoginMemberOf(emailVO, socialLoginType)));
 

--- a/src/main/java/com/prography/lighton/auth/presentation/AuthController.java
+++ b/src/main/java/com/prography/lighton/auth/presentation/AuthController.java
@@ -58,7 +58,7 @@ public class AuthController {
     public void socialLoginRedirect(
             @PathVariable(name = "socialLoginType") String socialLoginPath,
             HttpServletResponse response) throws IOException {
-        SocialLoginType socialLoginType = SocialLoginType.valueOf(socialLoginPath.toUpperCase());
+        SocialLoginType socialLoginType = SocialLoginType.from(socialLoginPath.toUpperCase());
         String redirectUrl = oAuthService.accessRequest(socialLoginType);
         response.sendRedirect(redirectUrl);
     }
@@ -68,7 +68,7 @@ public class AuthController {
     public ResponseEntity<ApiResult<SocialLoginResult>> socialLoginCallback(
             @PathVariable(name = "socialLoginType") String socialLoginPath,
             @RequestParam(name = "code") String code) throws RuntimeException {
-        SocialLoginType socialLoginType = SocialLoginType.valueOf(socialLoginPath.toUpperCase());
+        SocialLoginType socialLoginType = SocialLoginType.from(socialLoginPath.toUpperCase());
         return ResponseEntity.status(HttpStatus.OK)
                 .body(ApiUtils.success(oAuthService.oAuthLoginOrJoin(socialLoginType, code)));
     }

--- a/src/main/java/com/prography/lighton/auth/presentation/exception/AuthExceptionHandler.java
+++ b/src/main/java/com/prography/lighton/auth/presentation/exception/AuthExceptionHandler.java
@@ -9,11 +9,13 @@ import com.prography.lighton.auth.infrastructure.sms.exception.SmsSendFailedExce
 import com.prography.lighton.auth.security.exception.ForbiddenException;
 import com.prography.lighton.auth.security.exception.UnauthorizedException;
 import com.prography.lighton.common.utils.ApiUtils;
+import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Order(1)
 @RestControllerAdvice
 public class AuthExceptionHandler {
 

--- a/src/main/java/com/prography/lighton/member/common/infrastructure/repository/TemporaryMemberRepository.java
+++ b/src/main/java/com/prography/lighton/member/common/infrastructure/repository/TemporaryMemberRepository.java
@@ -11,13 +11,15 @@ import org.springframework.data.repository.query.Param;
 
 public interface TemporaryMemberRepository extends JpaRepository<TemporaryMember, Long> {
 
-    @Query("SELECT m FROM TemporaryMember m WHERE m.email.value = :email AND not m.isRegistered")
-    Optional<TemporaryMember> findByEmailAndNotRegistered(@Param("email") String email);
+    @Query("SELECT m FROM TemporaryMember m WHERE m.email.value = :email AND m.loginType = :socialLoginType AND not m.isRegistered")
+    Optional<TemporaryMember> findByEmailAndSocialLoginTypeAndNotRegistered(@Param("email") String email,
+                                                                            @Param("socialLoginType") SocialLoginType socialLoginType);
 
     void deleteByEmail(Email email);
 
-    @Query("SELECT COUNT(m) > 0 FROM TemporaryMember m WHERE m.email.value = :email AND not m.isRegistered")
-    boolean existsByEmailAndNotRegistered(@Param("email") String email);
+    @Query("SELECT COUNT(m) > 0 FROM TemporaryMember m WHERE m.email.value = :email AND m.loginType = :socialLoginType AND not m.isRegistered")
+    boolean existsByEmailAndSocialLoginTypeAndNotRegistered(@Param("email") String email,
+                                                            @Param("socialLoginType") SocialLoginType socialLoginType);
 
     @Query("SELECT COUNT(m) > 0 FROM TemporaryMember m WHERE m.email.value = :email")
     boolean existsByEmail(@Param("email") String email);

--- a/src/main/java/com/prography/lighton/member/common/infrastructure/repository/TemporaryMemberRepository.java
+++ b/src/main/java/com/prography/lighton/member/common/infrastructure/repository/TemporaryMemberRepository.java
@@ -11,7 +11,8 @@ import org.springframework.data.repository.query.Param;
 
 public interface TemporaryMemberRepository extends JpaRepository<TemporaryMember, Long> {
 
-    Optional<TemporaryMember> findByEmail(Email email);
+    @Query("SELECT m FROM TemporaryMember m WHERE m.email.value = :email AND not m.isRegistered")
+    Optional<TemporaryMember> findByEmailAndNotRegistered(@Param("email") String email);
 
     void deleteByEmail(Email email);
 

--- a/src/test/java/com/prography/lighton/auth/application/service/LoginMemberServiceTest.java
+++ b/src/test/java/com/prography/lighton/auth/application/service/LoginMemberServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.prography.lighton.auth.application.fake.FakeTokenProvider;
 import com.prography.lighton.auth.application.validator.DuplicateEmailValidator;
+import com.prography.lighton.auth.domain.enums.SocialLoginType;
 import com.prography.lighton.member.common.domain.entity.Member;
 import com.prography.lighton.member.common.domain.exception.InvalidMemberException;
 import com.prography.lighton.member.common.infrastructure.repository.MemberRepository;
@@ -57,7 +58,8 @@ class LoginMemberServiceTest {
         Member member = createNormalMember(passwordEncoder);
         ReflectionTestUtils.setField(member, "id", 1L);
         when(memberRepository.getMemberByEmail(member.getEmail())).thenReturn(member);
-        when(temporaryMemberRepository.existsByEmailAndNotRegistered(member.getEmail().getValue())).thenReturn(false);
+        when(temporaryMemberRepository.existsByEmailAndSocialLoginTypeAndNotRegistered(member.getEmail().getValue(),
+                SocialLoginType.DEFAULT)).thenReturn(false);
         when(passwordEncoder.matches(password, member.getPassword().getValue())).thenReturn(true);
 
         // When
@@ -75,7 +77,8 @@ class LoginMemberServiceTest {
     void should_not_allow_temporary_member_to_login() {
         // Given
         Member member = createNormalMember(passwordEncoder);
-        when(temporaryMemberRepository.existsByEmailAndNotRegistered(member.getEmail().getValue())).thenReturn(true);
+        when(temporaryMemberRepository.existsByEmailAndSocialLoginTypeAndNotRegistered(member.getEmail().getValue(),
+                SocialLoginType.DEFAULT)).thenReturn(true);
 
         // When & Then
         assertThrows(InvalidMemberException.class, () ->
@@ -89,7 +92,8 @@ class LoginMemberServiceTest {
         // Given
         Member member = createNormalMember(passwordEncoder);
         when(memberRepository.getMemberByEmail(member.getEmail())).thenReturn(member);
-        when(temporaryMemberRepository.existsByEmailAndNotRegistered(member.getEmail().getValue())).thenReturn(false);
+        when(temporaryMemberRepository.existsByEmailAndSocialLoginTypeAndNotRegistered(member.getEmail().getValue(),
+                SocialLoginType.DEFAULT)).thenReturn(false);
         when(passwordEncoder.matches("WrongPassword", member.getPassword().getValue())).thenReturn(false);
 
         // When & Then


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)

## 🔧 작업 내용
- 같은 이메일로 임시 회원 여러개 만들 수 있도록 로직 변경
- 잘못된 소셜 로그인 타입 입력 시, 에러 핸들링
- Auth 관련 예외 처리기 적용
## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevented social login failures caused by incomplete profiles by reusing unregistered accounts per provider.
  - Ensured login flow for existing members remains stable.
- Improvements
  - More robust provider parsing in social login redirect and callback for better reliability.
  - Adjusted exception handling priority to return consistent authentication error responses.
- Tests
  - Updated test cases to validate provider-specific temporary account checks during login.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->