### PR TITLE
[Feature] 공연 엔티티에 아티스트 이름, 설명 필드 추가

### DIFF
--- a/src/main/java/com/prography/lighton/artist/users/application/service/ArtistService.java
+++ b/src/main/java/com/prography/lighton/artist/users/application/service/ArtistService.java
@@ -1,18 +1,14 @@
 package com.prography.lighton.artist.users.application.service;
 
-import static java.util.stream.Collectors.collectingAndThen;
-import static java.util.stream.Collectors.toList;
-
 import com.prography.lighton.artist.common.domain.entity.Artist;
 import com.prography.lighton.artist.common.domain.entity.enums.ApproveStatus;
-import com.prography.lighton.artist.users.application.exception.NoSuchArtistException;
 import com.prography.lighton.artist.users.application.resolver.ArtistRequestResolver;
 import com.prography.lighton.artist.users.infrastructure.repository.ArtistRepository;
 import com.prography.lighton.artist.users.presentation.dto.request.RegisterArtistMultipart;
 import com.prography.lighton.artist.users.presentation.dto.request.UpdateArtistMultipart;
 import com.prography.lighton.artist.users.presentation.dto.response.ArtistCheckResponseDTO;
+import com.prography.lighton.artist.users.presentation.dto.response.GetMyArtistInfoResponse;
 import com.prography.lighton.member.common.domain.entity.Member;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,15 +27,9 @@ public class ArtistService {
         return artist;
     }
 
-    public List<Artist> getApprovedArtistsByIds(List<Long> artistIds) {
-        return artistRepository.findAllById(artistIds).stream()
-                .peek(Artist::isValidApproved)
-                .collect(collectingAndThen(toList(), list -> {
-                    if (list.size() != artistIds.size()) {
-                        throw new NoSuchArtistException();
-                    }
-                    return list;
-                }));
+    public GetMyArtistInfoResponse getMyArtistInfo(Member member) {
+        Artist artist = artistRepository.getByMember(member);
+        return GetMyArtistInfoResponse.of(artist.getStageName(), artist.getDescription());
     }
 
     @Transactional

--- a/src/main/java/com/prography/lighton/artist/users/presentation/controller/ArtistController.java
+++ b/src/main/java/com/prography/lighton/artist/users/presentation/controller/ArtistController.java
@@ -5,6 +5,7 @@ import com.prography.lighton.artist.users.presentation.dto.request.RegisterArtis
 import com.prography.lighton.artist.users.presentation.dto.request.SaveArtistRequest;
 import com.prography.lighton.artist.users.presentation.dto.request.UpdateArtistMultipart;
 import com.prography.lighton.artist.users.presentation.dto.response.ArtistCheckResponseDTO;
+import com.prography.lighton.artist.users.presentation.dto.response.GetMyArtistInfoResponse;
 import com.prography.lighton.common.annotation.LoginMember;
 import com.prography.lighton.common.utils.ApiUtils;
 import com.prography.lighton.common.utils.ApiUtils.ApiResult;
@@ -75,5 +76,10 @@ public class ArtistController {
     @GetMapping("/me")
     public ResponseEntity<ApiResult<ArtistCheckResponseDTO>> checkIsArtist(@LoginMember Member member) {
         return ResponseEntity.ok(ApiUtils.success(artistService.isArtist(member)));
+    }
+
+    @GetMapping("/me/info")
+    public ResponseEntity<ApiResult<GetMyArtistInfoResponse>> getMyArtistInfo(@LoginMember Member member) {
+        return ResponseEntity.ok(ApiUtils.success(artistService.getMyArtistInfo(member)));
     }
 }

--- a/src/main/java/com/prography/lighton/artist/users/presentation/dto/response/GetMyArtistInfoResponse.java
+++ b/src/main/java/com/prography/lighton/artist/users/presentation/dto/response/GetMyArtistInfoResponse.java
@@ -1,0 +1,10 @@
+package com.prography.lighton.artist.users.presentation.dto.response;
+
+public record GetMyArtistInfoResponse(
+        String artistName,
+        String artistDescription
+) {
+    public static GetMyArtistInfoResponse of(String artistName, String artistDescription) {
+        return new GetMyArtistInfoResponse(artistName, artistDescription);
+    }
+}

--- a/src/main/java/com/prography/lighton/performance/common/application/mapper/PerformanceDetailMapper.java
+++ b/src/main/java/com/prography/lighton/performance/common/application/mapper/PerformanceDetailMapper.java
@@ -50,11 +50,12 @@ public class PerformanceDetailMapper {
                 .id(p.getId())
                 .info(p.getInfo())
                 .artists(
-                        p.getArtists().stream()
-                                .map(pa -> ArtistDTO.of(pa.getArtist().getId(),
-                                        pa.getArtist().getStageName(),
-                                        pa.getArtist().getDescription()))
-                                .toList())
+                        List.of(
+                                ArtistDTO.of(
+                                        p.getArtists().get(0).getArtist().getId(),
+                                        p.getArtistName(),
+                                        p.getArtistDescription()
+                                )))
                 .genres(toGenres(p.getGenres()))
                 .schedule(p.getSchedule())
                 .regionCode(regionCache.getRegionCodeByInfo(p.getLocation().getRegion()))
@@ -75,7 +76,7 @@ public class PerformanceDetailMapper {
             artistDto = ArtistDTO.of(null, b.getArtistName(), b.getArtistDescription());
         } else {
             var a = b.getArtists().get(0).getArtist();
-            artistDto = ArtistDTO.of(a.getId(), a.getStageName(), a.getDescription());
+            artistDto = ArtistDTO.of(a.getId(), b.getArtistName(), b.getArtistDescription());
         }
 
         return GetPerformanceDetailResponseDTO.builder()

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Busking.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Busking.java
@@ -11,7 +11,6 @@ import com.prography.lighton.performance.common.domain.entity.profile.Performanc
 import com.prography.lighton.performance.common.domain.entity.vo.Info;
 import com.prography.lighton.performance.common.domain.entity.vo.Location;
 import com.prography.lighton.performance.common.domain.entity.vo.Schedule;
-import jakarta.persistence.Column;
 import jakarta.persistence.DiscriminatorValue;
 import jakarta.persistence.Entity;
 import java.util.List;
@@ -30,12 +29,6 @@ public class Busking extends Performance {
 
     private static final int UPDATE_DEADLINE_DAYS = 3;
 
-    @Column(length = 100)
-    private String artistName;
-
-    @Column(length = 255)
-    private
-    String artistDescription;
 
     private Busking(
             Member performer,
@@ -56,10 +49,10 @@ public class Busking extends Performance {
                 proofUrl,
                 PerformanceProfile.busking(),
                 genres,
-                artists
+                artists,
+                artistName,
+                artistDescription
         );
-        this.artistName = artistName;
-        this.artistDescription = artistDescription;
     }
 
     public static Busking createByUser(
@@ -83,11 +76,13 @@ public class Busking extends Performance {
             Location location,
             List<Genre> genres,
             String proofUrl,
-            Artist artist
+            Artist artist,
+            String artistName,
+            String artistDescription
     ) {
         Busking busking = new Busking(
                 performer, info, schedule, location, proofUrl, genres,
-                List.of(artist), artist.getStageName(), artist.getDescription()
+                List.of(artist), artistName, artistDescription
         );
         busking.managePerformanceApplication(ApproveStatus.APPROVED);
         return busking;
@@ -104,7 +99,9 @@ public class Busking extends Performance {
             Schedule schedule,
             Location location,
             List<Genre> genres,
-            String proofUrl
+            String proofUrl,
+            String artistName,
+            String artistDescription
     ) {
         validatePerformer(performer);
         ensureUpdatableWindow();
@@ -114,7 +111,9 @@ public class Busking extends Performance {
                 schedule,
                 location,
                 proofUrl,
-                genres
+                genres,
+                artistName,
+                artistDescription
         );
     }
 
@@ -135,15 +134,14 @@ public class Busking extends Performance {
         DomainValidator.requireNonBlank(artistName);
         DomainValidator.requireNonBlank(artistDescription);
 
-        this.artistName = artistName;
-        this.artistDescription = artistDescription;
-
         updateCommonDetails(
                 info,
                 schedule,
                 location,
                 proofUrl,
-                genres
+                genres,
+                artistName,
+                artistDescription
         );
     }
 }

--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/Performance.java
@@ -119,6 +119,13 @@ public class Performance extends BaseEntity {
 
     private LocalDateTime approvedAt;
 
+    @Column(length = 100)
+    private String artistName;
+
+    @Column(length = 255)
+    private
+    String artistDescription;
+
     protected Performance(
             Member performer,
             Info info,
@@ -127,13 +134,17 @@ public class Performance extends BaseEntity {
             String proofUrl,
             PerformanceProfile profile,
             List<Genre> genres,
-            List<Artist> artists
+            List<Artist> artists,
+            String artistName,
+            String artistDescription
     ) {
         this.performer = performer;
         this.info = info;
         this.schedule = schedule;
         this.location = location;
         this.proofUrl = proofUrl;
+        this.artistName = artistName;
+        this.artistDescription = artistDescription;
 
         this.type = profile.type();
         this.payment = profile.payment();
@@ -155,7 +166,9 @@ public class Performance extends BaseEntity {
             List<Seat> seats,
             List<Genre> genres,
             String proofUrl,
-            int totalSeatsCount
+            int totalSeatsCount,
+            String artistName,
+            String artistDescription
     ) {
         return new Performance(
                 performer,
@@ -165,7 +178,9 @@ public class Performance extends BaseEntity {
                 proofUrl,
                 PerformanceProfile.concert(payment, seats, totalSeatsCount),
                 genres,
-                artists
+                artists,
+                artistName,
+                artistDescription
         );
     }
 
@@ -180,13 +195,15 @@ public class Performance extends BaseEntity {
             List<Seat> seats,
             List<Genre> genres,
             String proofUrl,
-            int totalSeatsCount
+            int totalSeatsCount,
+            String artistName,
+            String artistDescription
     ) {
         validatePerformer(performer);
         ensureUpdatableWindow();
         DomainValidator.requireNonBlank(proofUrl);
 
-        updateCommonDetails(info, schedule, location, proofUrl, genres);
+        updateCommonDetails(info, schedule, location, proofUrl, genres, artistName, artistDescription);
         this.payment = payment;
         this.seats.clear();
         this.seats.addAll(seats);
@@ -200,12 +217,17 @@ public class Performance extends BaseEntity {
             Schedule schedule,
             Location location,
             String proofUrl,
-            List<Genre> genres
+            List<Genre> genres,
+            String artistName,
+            String artistDescription
     ) {
         this.info = info;
         this.schedule = schedule;
         this.location = location;
         this.proofUrl = proofUrl;
+
+        this.artistName = artistName;
+        this.artistDescription = artistDescription;
 
         updateGenres(genres);
     }

--- a/src/main/java/com/prography/lighton/performance/users/application/resolver/PerformanceResolver.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/resolver/PerformanceResolver.java
@@ -43,7 +43,7 @@ public class PerformanceResolver {
         SavePerformanceRequest data = request.data();
 
         return new PerformanceData(
-                toArtists(member, data.artists()),
+                toArtists(member),
                 toInfo(data.info(), posterUrl),
                 toSchedule(data.schedule()),
                 toLocation(data.info()),
@@ -63,7 +63,7 @@ public class PerformanceResolver {
         SavePerformanceRequest data = request.data();
 
         return new PerformanceData(
-                toArtists(member, data.artists()),
+                toArtists(member),
                 toInfo(data.info(), posterUrl),
                 toSchedule(data.schedule()),
                 toLocation(data.info()),
@@ -104,10 +104,9 @@ public class PerformanceResolver {
                 proofUrl);
     }
 
-    private List<Artist> toArtists(Member member, List<Long> artistIds) {
+    private List<Artist> toArtists(Member member) {
         Artist artist = artistService.getApprovedArtistByMember(member);
-        artistIds.add(artist.getId());
-        return artistService.getApprovedArtistsByIds(artistIds);
+        return List.of(artist);
     }
 
     private Info toInfo(InfoDTO req, String posterUrl) {

--- a/src/main/java/com/prography/lighton/performance/users/application/service/ArtistPerformanceService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/ArtistPerformanceService.java
@@ -48,7 +48,8 @@ public class ArtistPerformanceService {
         var data = performanceResolver.toNewPerformanceData(member, request);
         Performance performance = Performance.create(member, data.artists(), data.info(), data.schedule(),
                 data.location(),
-                data.payment(), data.seats(), data.genres(), data.proofUrl(), request.data().totalSeatsCount());
+                data.payment(), data.seats(), data.genres(), data.proofUrl(), request.data().totalSeatsCount(),
+                request.data().artistName(), request.data().artistDescription());
         performanceRepository.save(performance);
     }
 
@@ -58,7 +59,8 @@ public class ArtistPerformanceService {
         var data = performanceResolver.toUpdatePerformanceData(member, performance, request);
         performance.update(member, data.artists(), data.info(), data.schedule(), data.location(), data.payment(),
                 data.seats(),
-                data.genres(), data.proofUrl(), request.data().totalSeatsCount());
+                data.genres(), data.proofUrl(), request.data().totalSeatsCount(), request.data().artistName(),
+                request.data().artistDescription());
     }
 
     @Transactional

--- a/src/main/java/com/prography/lighton/performance/users/application/service/BuskingService.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/service/BuskingService.java
@@ -45,7 +45,8 @@ public class BuskingService {
                 request.posterImage(),
                 request.proof());
         Busking busking = Busking.createByArtist(member, data.info(), data.schedule(),
-                data.location(), data.genres(), data.proofUrl(), artist);
+                data.location(), data.genres(), data.proofUrl(), artist, request.data().artistName(),
+                request.data().artistDescription());
         performanceRepository.save(busking);
     }
 
@@ -66,7 +67,8 @@ public class BuskingService {
         var data = performanceResolver.toUpdateBuskingData(member, busking, request.data().info(),
                 request.data().schedule(),
                 request.posterImage(), request.proof());
-        busking.updateByArtist(member, data.info(), data.schedule(), data.location(), data.genres(), data.proofUrl());
+        busking.updateByArtist(member, data.info(), data.schedule(), data.location(), data.genres(), data.proofUrl(),
+                request.data().artistName(), request.data().artistDescription());
     }
 
     @Transactional

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/ArtistBuskingUpdateRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/ArtistBuskingUpdateRequest.java
@@ -1,6 +1,7 @@
 package com.prography.lighton.performance.users.presentation.dto.request;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record ArtistBuskingUpdateRequest(
@@ -11,7 +12,13 @@ public record ArtistBuskingUpdateRequest(
 
         @NotNull(message = "공연 일정 정보는 필수입니다.")
         @Valid
-        ScheduleDTO schedule
+        ScheduleDTO schedule,
+        
+        @NotBlank(message = "아티스트 이름은 필수입니다.")
+        String artistName,
+
+        @NotBlank(message = "아티스트 설명은 필수입니다.")
+        String artistDescription
 
 ) {
 }

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/PerformanceUpdateRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/PerformanceUpdateRequest.java
@@ -2,13 +2,12 @@ package com.prography.lighton.performance.users.presentation.dto.request;
 
 import com.prography.lighton.performance.common.domain.entity.enums.Seat;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record PerformanceUpdateRequest(
-
-        List<@NotNull(message = "아티스트 ID에는 빈 값이 들어갈 수 없습니다.") Long> artists,
 
         @NotNull(message = "공연 기본 정보는 필수입니다.")
         @Valid
@@ -23,7 +22,14 @@ public record PerformanceUpdateRequest(
         PaymentDTO payment,
 
         @NotEmpty(message = "좌석 유형은 하나 이상 선택해야 합니다.")
-        List<@NotNull(message = "좌석 유형은 비어 있을 수 없습니다.") Seat> seat
+        List<@NotNull(message = "좌석 유형은 비어 있을 수 없습니다.") Seat> seat,
+
+
+        @NotBlank(message = "아티스트 이름은 필수입니다.")
+        String artistName,
+
+        @NotBlank(message = "아티스트 설명은 필수입니다.")
+        String artistDescription
 
 ) {
 }

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/SaveArtistBuskingRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/SaveArtistBuskingRequest.java
@@ -1,6 +1,7 @@
 package com.prography.lighton.performance.users.presentation.dto.request;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
 public record SaveArtistBuskingRequest(
@@ -11,7 +12,13 @@ public record SaveArtistBuskingRequest(
 
         @NotNull(message = "공연 일정 정보는 필수입니다.")
         @Valid
-        ScheduleDTO schedule
+        ScheduleDTO schedule,
+
+        @NotBlank(message = "아티스트 이름은 필수입니다.")
+        String artistName,
+
+        @NotBlank(message = "아티스트 설명은 필수입니다.")
+        String artistDescription
 
 ) {
 }

--- a/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/SavePerformanceRequest.java
+++ b/src/main/java/com/prography/lighton/performance/users/presentation/dto/request/SavePerformanceRequest.java
@@ -2,13 +2,12 @@ package com.prography.lighton.performance.users.presentation.dto.request;
 
 import com.prography.lighton.performance.common.domain.entity.enums.Seat;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import java.util.List;
 
 public record SavePerformanceRequest(
-
-        List<@NotNull(message = "아티스트 ID에는 빈 값이 들어갈 수 없습니다.") Long> artists,
 
         @NotNull(message = "공연 기본 정보는 필수입니다.")
         @Valid
@@ -25,7 +24,13 @@ public record SavePerformanceRequest(
         @NotEmpty(message = "좌석 유형은 하나 이상 선택해야 합니다.")
         List<@NotNull(message = "좌석 유형은 비어 있을 수 없습니다.") Seat> seat,
 
-        int totalSeatsCount
+        int totalSeatsCount,
+
+        @NotBlank(message = "아티스트 이름은 필수입니다.")
+        String artistName,
+
+        @NotBlank(message = "아티스트 설명은 필수입니다.")
+        String artistDescription
 
 ) {
 }

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/BuskingCreateTest.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/BuskingCreateTest.java
@@ -34,7 +34,9 @@ class BuskingCreateTest {
                     PerformanceFixture.defaultLocation(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    artist);
+                    artist,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION);
 
             assertThat(b.getType()).isEqualTo(Type.BUSKING);
             assertThat(b.getPerformer().getId()).isEqualTo(PerformanceFixture.DEFAULT_PERFORMER_ID);
@@ -83,7 +85,9 @@ class BuskingCreateTest {
                     PerformanceFixture.defaultLocation(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    artist
+                    artist,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             assertThat(b.getArtistName()).isEqualTo(artistName);
@@ -117,7 +121,9 @@ class BuskingCreateTest {
                     PerformanceFixture.defaultLocation(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    artist
+                    artist,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             )).isInstanceOf(MasterArtistCannotBeRemovedException.class);
         }
     }

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/BuskingCreateTest.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/BuskingCreateTest.java
@@ -69,32 +69,6 @@ class BuskingCreateTest {
         }
 
         @Test
-        @DisplayName("아티스트 Busking 생성 시 이름·설명은 Artist 엔티티 값이 들어간다")
-        void should_set_artist_fields_from_artist_entity() {
-            Member performer = PerformanceFixture.defaultMember();
-            Artist artist = PerformanceFixture.defaultArtist(performer);
-            String artistName = "name";
-            String artistDescription = "description";
-            when(artist.getStageName()).thenReturn(artistName);
-            when(artist.getDescription()).thenReturn(artistDescription);
-
-            Busking b = Busking.createByArtist(
-                    performer,
-                    PerformanceFixture.defaultInfo(),
-                    PerformanceFixture.defaultSchedule(),
-                    PerformanceFixture.defaultLocation(),
-                    PerformanceFixture.defaultGenres(),
-                    PerformanceFixture.DEFAULT_PROOF_URL,
-                    artist,
-                    PerformanceFixture.ARTIST_NAME,
-                    PerformanceFixture.ARTIST_DESCRIPTION
-            );
-
-            assertThat(b.getArtistName()).isEqualTo(artistName);
-            assertThat(b.getArtistDescription()).isEqualTo(artistDescription);
-        }
-
-        @Test
         @DisplayName("아티스트 Busking 생성 시 PerformanceArtist 리스트가 초기화된다")
         void should_init_performanceArtist_list() {
             Busking b = BuskingFixture.defaultBuskingByArtist();

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/BuskingUpdateTest.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/BuskingUpdateTest.java
@@ -36,7 +36,9 @@ class BuskingUpdateTest {
                     PerformanceFixture.defaultLocation(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    artist);
+                    artist,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION);
 
             Info updatedInfo = Info.of("수정 제목", "수정 설명", "수정 장소", "", "");
 
@@ -44,7 +46,9 @@ class BuskingUpdateTest {
                     performer,
                     updatedInfo, PerformanceFixture.defaultSchedule(), PerformanceFixture.defaultLocation(),
                     PerformanceFixture.defaultGenres(),
-                    PerformanceFixture.DEFAULT_PROOF_URL
+                    PerformanceFixture.DEFAULT_PROOF_URL,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             assertThat(b.getInfo()).isEqualTo(updatedInfo);
@@ -62,7 +66,9 @@ class BuskingUpdateTest {
             assertThatThrownBy(() -> b.updateByArtist(
                     notPerformer,
                     b.getInfo(), b.getSchedule(), b.getLocation(),
-                    PerformanceFixture.defaultGenres(), "수정 url"
+                    PerformanceFixture.defaultGenres(), "수정 url",
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             )).isInstanceOf(NotAuthorizedPerformanceAccessException.class);
         }
 
@@ -80,7 +86,9 @@ class BuskingUpdateTest {
 
             assertThatThrownBy(() -> b.updateByArtist(
                     b.getPerformer(), b.getInfo(), near, b.getLocation(),
-                    PerformanceFixture.defaultGenres(), "수정 url"
+                    PerformanceFixture.defaultGenres(), "수정 url",
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             )).isInstanceOf(PerformanceUpdateNotAllowedException.class);
         }
     }

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/PerformanceCreateTest.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/PerformanceCreateTest.java
@@ -25,7 +25,9 @@ class PerformanceCreateTest {
                 PerformanceFixture.defaultSeats(),
                 PerformanceFixture.defaultGenres(),
                 PerformanceFixture.DEFAULT_PROOF_URL,
-                PerformanceFixture.DEFAULT_TOTAL_SEATS
+                PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                PerformanceFixture.ARTIST_NAME,
+                PerformanceFixture.ARTIST_DESCRIPTION
         );
 
         assertThat(p.getPerformer().getId()).isEqualTo(PerformanceFixture.DEFAULT_PERFORMER_ID);

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/PerformanceUpdateTest.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/PerformanceUpdateTest.java
@@ -43,7 +43,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             Info updatedInfo = Info.of("수정 제목", "수정 설명", "수정 장소", "", "");
@@ -57,7 +59,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             // then
@@ -79,7 +83,9 @@ class PerformanceUpdateTest {
                             PerformanceFixture.defaultSeats(),
                             PerformanceFixture.defaultGenres(),
                             PerformanceFixture.DEFAULT_PROOF_URL,
-                            PerformanceFixture.DEFAULT_TOTAL_SEATS
+                            PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                            PerformanceFixture.ARTIST_NAME,
+                            PerformanceFixture.ARTIST_DESCRIPTION
                     )
             ).isInstanceOf(NotAuthorizedPerformanceAccessException.class);
         }
@@ -109,7 +115,9 @@ class PerformanceUpdateTest {
                             PerformanceFixture.defaultSeats(),
                             PerformanceFixture.defaultGenres(),
                             PerformanceFixture.DEFAULT_PROOF_URL,
-                            PerformanceFixture.DEFAULT_TOTAL_SEATS
+                            PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                            PerformanceFixture.ARTIST_NAME,
+                            PerformanceFixture.ARTIST_DESCRIPTION
                     )
             ).isInstanceOf(PerformanceUpdateNotAllowedException.class);
         }
@@ -130,7 +138,9 @@ class PerformanceUpdateTest {
                             PerformanceFixture.defaultSeats(),
                             PerformanceFixture.defaultGenres(),
                             " ",
-                            PerformanceFixture.DEFAULT_TOTAL_SEATS
+                            PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                            PerformanceFixture.ARTIST_NAME,
+                            PerformanceFixture.ARTIST_DESCRIPTION
                     )
             ).isInstanceOf(IllegalArgumentException.class);
         }
@@ -157,7 +167,9 @@ class PerformanceUpdateTest {
                             PerformanceFixture.defaultSeats(),
                             PerformanceFixture.defaultGenres(),
                             PerformanceFixture.DEFAULT_PROOF_URL,
-                            updateSeatCount
+                            updateSeatCount,
+                            PerformanceFixture.ARTIST_NAME,
+                            PerformanceFixture.ARTIST_DESCRIPTION
                     )
             ).isInstanceOf(InvalidSeatCountException.class);
         }
@@ -181,7 +193,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             // when: 마스터 아티스트(공연 등록자) 제거
@@ -196,7 +210,10 @@ class PerformanceUpdateTest {
                             PerformanceFixture.defaultSeats(),
                             PerformanceFixture.defaultGenres(),
                             PerformanceFixture.DEFAULT_PROOF_URL,
-                            PerformanceFixture.DEFAULT_TOTAL_SEATS)
+                            PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                            PerformanceFixture.ARTIST_NAME,
+                            PerformanceFixture.ARTIST_DESCRIPTION)
+
             ).isInstanceOf(MasterArtistCannotBeRemovedException.class);
         }
 
@@ -219,7 +236,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             // when: a2 제거
@@ -233,7 +252,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             // then
@@ -264,7 +285,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     PerformanceFixture.defaultGenres(),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             assertThat(p.getArtists()).hasSize(2)
@@ -290,7 +313,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     List.of(g1, g2),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             // when: g2 제거
@@ -304,7 +329,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     List.of(g1),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             assertThat(p.getGenres()).hasSize(1)
@@ -333,7 +360,9 @@ class PerformanceUpdateTest {
                     PerformanceFixture.defaultSeats(),
                     List.of(existing, newGenre),
                     PerformanceFixture.DEFAULT_PROOF_URL,
-                    PerformanceFixture.DEFAULT_TOTAL_SEATS
+                    PerformanceFixture.DEFAULT_TOTAL_SEATS,
+                    PerformanceFixture.ARTIST_NAME,
+                    PerformanceFixture.ARTIST_DESCRIPTION
             );
 
             assertThat(p.getGenres()).hasSize(2)

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/fixture/BuskingFixture.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/fixture/BuskingFixture.java
@@ -46,7 +46,9 @@ public class BuskingFixture {
                 PerformanceFixture.defaultLocation(),
                 PerformanceFixture.defaultGenres(),
                 PerformanceFixture.DEFAULT_PROOF_URL,
-                artist
+                artist,
+                ARTIST_NAME,
+                ARTIST_DESCRIPTION
         );
     }
 
@@ -58,7 +60,9 @@ public class BuskingFixture {
                 PerformanceFixture.defaultLocation(),
                 PerformanceFixture.defaultGenres(),
                 PerformanceFixture.DEFAULT_PROOF_URL,
-                artist
+                artist,
+                ARTIST_NAME,
+                ARTIST_DESCRIPTION
         );
     }
 }

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/fixture/PerformanceFixture.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/fixture/PerformanceFixture.java
@@ -35,6 +35,8 @@ public class PerformanceFixture {
     public static final double DEFAULT_LONGITUDE = 0.0;
     public static final String DEFAULT_PROOF_URL = "http://proof.url";
     public static final int DEFAULT_TOTAL_SEATS = 50;
+    public static final String ARTIST_NAME = "아티스트 이름";
+    public static final String ARTIST_DESCRIPTION = "아티스트 설명";
 
 
     public static Info defaultInfo() {
@@ -105,7 +107,9 @@ public class PerformanceFixture {
                 defaultSeats(),
                 defaultGenres(),
                 DEFAULT_PROOF_URL,
-                DEFAULT_TOTAL_SEATS
+                DEFAULT_TOTAL_SEATS,
+                ARTIST_NAME,
+                ARTIST_DESCRIPTION
         );
     }
 


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)
close: #163 
## 🔧 작업 내용
공연 엔티티에 아티스트 이름, 설명 필드 추가
공연 등록/수정 시 아티스트 이름, 설명 받도록 수정
공연 조회 시 공연 엔티티에 있는 아티스트 이름, 설명 필드 사용
## 💬 기타 사항
