### PR TITLE
[Hotfix] 무료 공연일 때도 결제 정보 요청 에러 해결

### DIFF
--- a/src/main/java/com/prography/lighton/performance/common/domain/entity/vo/Payment.java
+++ b/src/main/java/com/prography/lighton/performance/common/domain/entity/vo/Payment.java
@@ -28,8 +28,8 @@ public class Payment {
 
     private Integer fee;
 
-    public static Payment of(String account, String bank, String accountHolder, Integer fee) {
-        if (isInvalid(account, bank, accountHolder, fee)) {
+    public static Payment of(Boolean isPaid, String account, String bank, String accountHolder, Integer fee) {
+        if (isPaid && isInvalid(account, bank, accountHolder, fee)) {
             throw new InvalidPaymentInfoException();
         }
 

--- a/src/main/java/com/prography/lighton/performance/users/application/resolver/PerformanceResolver.java
+++ b/src/main/java/com/prography/lighton/performance/users/application/resolver/PerformanceResolver.java
@@ -142,6 +142,7 @@ public class PerformanceResolver {
 
     private Payment toPayment(PaymentDTO req) {
         return Payment.of(
+                req.isPaid(),
                 req.account(),
                 req.bank(),
                 req.accountHolder(),

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/PaymentTest.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/PaymentTest.java
@@ -16,7 +16,7 @@ class PaymentTest {
     @Test
     @DisplayName("Payment 객체를 정상적으로 생성할 수 있다.")
     void should_create_paid_payment() {
-        Payment payment = Payment.of("1234-5678", "카카오뱅크", "홍길동", 10000);
+        Payment payment = Payment.of(true, "1234-5678", "카카오뱅크", "홍길동", 10000);
 
         assertTrue(payment.getIsPaid());
         assertEquals("1234-5678", payment.getAccount());
@@ -28,7 +28,7 @@ class PaymentTest {
     @Test
     @DisplayName("Payment 생성 시 기본값은 유료 형식이어야한다.")
     void should_be_paid_by_default_when_created_with_of() {
-        Payment payment = Payment.of("1234-5678", "은행", "예금주", 5000);
+        Payment payment = Payment.of(true, "1234-5678", "은행", "예금주", 5000);
         assertTrue(payment.getIsPaid());
     }
 
@@ -36,10 +36,10 @@ class PaymentTest {
     @DisplayName("계좌가 빈 값이면 에러가 발생한다.")
     void should_throw_exception_when_account_is_blank() {
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("", "은행", "예금주", 1000)
+                Payment.of(true, "", "은행", "예금주", 1000)
         );
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of(" ", "은행", "예금주", 1000)
+                Payment.of(true, " ", "은행", "예금주", 1000)
         );
     }
 
@@ -47,10 +47,10 @@ class PaymentTest {
     @DisplayName("은행이 빈 값이면 에러가 발생한다.")
     void should_throw_exception_when_bank_is_blank() {
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", "", "예금주", 1000)
+                Payment.of(true, "계좌", "", "예금주", 1000)
         );
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", " ", "예금주", 1000)
+                Payment.of(true, "계좌", " ", "예금주", 1000)
         );
     }
 
@@ -58,10 +58,10 @@ class PaymentTest {
     @DisplayName("예금주가 빈 값이면 에러가 발생한다.")
     void should_throw_exception_when_account_holder_is_blank() {
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", "은행", "", 1000)
+                Payment.of(true, "계좌", "은행", "", 1000)
         );
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", "은행", " ", 1000)
+                Payment.of(true, "계좌", "은행", " ", 1000)
         );
     }
 
@@ -69,10 +69,10 @@ class PaymentTest {
     @DisplayName("금액이 0 이하이면 에러가 발생한다.")
     void should_throw_exception_when_fee_is_zero_or_negative() {
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", "은행", "예금주", 0)
+                Payment.of(true, "계좌", "은행", "예금주", 0)
         );
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", "은행", "예금주", -100)
+                Payment.of(true, "계좌", "은행", "예금주", -100)
         );
     }
 
@@ -80,7 +80,7 @@ class PaymentTest {
     @DisplayName("금액이 null이면 에러가 발생한다.")
     void should_throw_exception_when_fee_is_null() {
         assertThrows(InvalidPaymentInfoException.class, () ->
-                Payment.of("계좌", "은행", "예금주", null)
+                Payment.of(true, "계좌", "은행", "예금주", null)
         );
     }
 

--- a/src/test/java/com/prography/lighton/performance/common/domain/entity/fixture/PerformanceFixture.java
+++ b/src/test/java/com/prography/lighton/performance/common/domain/entity/fixture/PerformanceFixture.java
@@ -72,6 +72,7 @@ public class PerformanceFixture {
 
     public static Payment defaultPayment() {
         return Payment.of(
+                true,
                 DEFAULT_ACCOUNT,
                 DEFAULT_BANK,
                 DEFAULT_HOLDER,


### PR DESCRIPTION
## 📎 관련 이슈 (ex. #1000)

## 🔧 작업 내용
무로 공연일 때는 필드 유효성 검사를 하지 않도록 변경
## 💬 기타 사항


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Payments can now be created as paid or unpaid; the paid flag is accepted during creation.
  * Payment state from user requests is propagated through performance flows for consistent handling.

* **Bug Fixes**
  * Validation of payment details now runs only for payments marked as paid, allowing unpaid entries without full account info.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->